### PR TITLE
Fix clean so that next `make bridge` works as intended

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,12 @@ clean-azero:
 .PHONY: clean-eth
 clean-eth: # Remove eth node data
 clean-eth:
-	cd devnet-eth && ./clean.sh && echo "Done eth clean"
+	cd devnet-eth && ./clean.sh && echo "Done devnet-eth clean"
+	cd eth && rm -rf .openzeppelin && echo "Done eth clean"
 
 .PHONY: clean
 clean: # Remove all node data
-clean: clean-azero clean-eth
+clean: stop-local-bridgenet clean-azero clean-eth
 
 .PHONY: bootstrap-azero
 bootstrap-azero: # Bootstrap the node data

--- a/devnet-eth/clean.sh
+++ b/devnet-eth/clean.sh
@@ -1,3 +1,2 @@
-docker-compose -f devnet-eth-compose.yml down
 rm -Rf ./consensus/beacondata ./consensus/validatordata ./consensus/genesis.ssz
-rm -Rf ./execution/geth
+rm -Rf ./execution/geth ./execution/genesis.json


### PR DESCRIPTION
We weren't clearing `eth/.openzeppelin` which caused a strange behaviour during proxy deployment which would then fail.
This adds clearing that + redis instance as part of `clean`