### PR TITLE
A0-3980: Add relayer flags for overriding cache contents

### DIFF
--- a/relayer/scripts/entrypoint.sh
+++ b/relayer/scripts/entrypoint.sh
@@ -47,6 +47,14 @@ if [[ -n "${DEV_MODE}" ]]; then
   ARGS+=(--dev)
 fi
 
+if [[ -n "${OVERRIDE_AZERO_CACHE}" ]]; then
+  ARGS+=(--override-azero-cache)
+fi
+
+if [[ -n "${OVERRIDE_ETH_CACHE}" ]]; then
+  ARGS+=(--override-eth-cache)
+fi
+
 if [[ -n "${AZERO_START_BLOCK}" ]]; then
   ARGS+=(--default-sync-from-block-azero=${AZERO_START_BLOCK})
 fi

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -6,6 +6,12 @@ pub struct Config {
     #[arg(long)]
     pub dev: bool,
 
+    #[arg(long)]
+    pub override_azero_cache: bool,
+
+    #[arg(long)]
+    pub override_eth_cache: bool,
+
     #[arg(long, default_value = "0")]
     pub committee_id: u32,
 

--- a/relayer/src/listeners/azero.rs
+++ b/relayer/src/listeners/azero.rs
@@ -107,6 +107,7 @@ impl AlephZeroListener {
             default_sync_from_block_azero,
             name,
             sync_step,
+            override_azero_cache,
             ..
         } = &*config;
 
@@ -120,13 +121,17 @@ impl AlephZeroListener {
             config.azero_ref_time_limit,
             config.azero_proof_size_limit,
         )?;
-        let mut first_unprocessed_block_number = read_first_unprocessed_block_number(
-            name.clone(),
-            ALEPH_LAST_BLOCK_KEY.to_string(),
-            redis_connection.clone(),
-            *default_sync_from_block_azero,
-        )
-        .await;
+        let mut first_unprocessed_block_number = if *override_azero_cache {
+            *default_sync_from_block_azero
+        } else {
+            read_first_unprocessed_block_number(
+                name.clone(),
+                ALEPH_LAST_BLOCK_KEY.to_string(),
+                redis_connection.clone(),
+                *default_sync_from_block_azero,
+            )
+            .await
+        };
 
         // Add the first block number to the set of pending blocks.
         add_to_pending(first_unprocessed_block_number, pending_blocks.clone()).await;

--- a/relayer/src/listeners/eth.rs
+++ b/relayer/src/listeners/eth.rs
@@ -70,19 +70,24 @@ impl EthListener {
             name,
             default_sync_from_block_eth,
             sync_step,
+            override_eth_cache,
             ..
         } = &*config;
 
         let address = eth_contract_address.parse::<Address>()?;
         let contract = Most::new(address, Arc::clone(&eth_connection));
 
-        let mut first_unprocessed_block_number = read_first_unprocessed_block_number(
-            name.clone(),
-            ETH_LAST_BLOCK_KEY.to_string(),
-            redis_connection.clone(),
-            *default_sync_from_block_eth,
-        )
-        .await;
+        let mut first_unprocessed_block_number = if *override_eth_cache {
+            *default_sync_from_block_eth
+        } else {
+            read_first_unprocessed_block_number(
+                name.clone(),
+                ETH_LAST_BLOCK_KEY.to_string(),
+                redis_connection.clone(),
+                *default_sync_from_block_eth,
+            )
+            .await
+        };
 
         // Main Ethereum event loop.
         loop {


### PR DESCRIPTION
Adds a relayer flag (one for azero, one for eth) with causes relayer to ignore the initial value stored in redis cache.
Might be useful in case of catching up after relayer was offline for a long time/erroneous value appearing in cache.