### PR TITLE
A0-4026: Move concurrency block out of master commit workflow

### DIFF
--- a/.github/workflows/contracts-compile-and-deploy-to-bridgenet.yml
+++ b/.github/workflows/contracts-compile-and-deploy-to-bridgenet.yml
@@ -5,6 +5,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  group: "${{ github.ref }}-${{ github.workflow }}"
+  cancel-in-progress: false
+
 jobs:
   check-vars-and-secrets:
     name: Check vars and secrets

--- a/.github/workflows/on-master-branch-commit.yml
+++ b/.github/workflows/on-master-branch-commit.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - master
 
-concurrency:
-  group: "${{ github.ref }}-${{ github.workflow }}"
-  cancel-in-progress: false
-
 jobs:
   check-vars-and-secrets:
     name: Check vars and secrets


### PR DESCRIPTION
A small bug got introduced with previous commit.  Concurrency setup in master commit workflow broke the workflows, hence it's been moved into one of the sub-workflows. 