### PR TITLE
A0-3990: Add a Makefile target to print contract hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,20 @@ compile-azero-docker: azero-deps most-builder
 		most-builder \
 		make compile-azero
 
+.PHONY: print-azero-codehashes
+print-azero-codehashes: # Print codehashes of azero contracts compiled in docker
+print-azero-codehashes: compile-azero-docker
+	@echo
+	@echo "-------------------"
+	@echo "CONTRACT CODEHASHES"
+	@echo "-------------------"
+	@echo
+
+	@cd azero && for file in artifacts/*.json; do \
+		echo "$$file"; \
+		cat "$$file" | jq '.source .hash'; \
+	done
+
 .PHONY: deploy-azero-docker
 deploy-azero-docker: # Deploy azero contracts compiling in docker
 deploy-azero-docker: azero-deps compile-azero-docker

--- a/README.md
+++ b/README.md
@@ -138,3 +138,15 @@ make deploy-azero
 ```bash
 make run-relayers
 ```
+
+## Verifying deployed contracts against source code
+
+Given a deployed (by us) Aleph Zero contract with some code hash `C` it's possible to check that the contract has been
+produced from a certain version of the source code in this repo (say a given commit). To do so:
+
+1. `git checkout $COMMIT`
+2. `make print-azero-codehashes`
+3. Find the contract in question in the list and ensure that the printed code hash is the same as `C`
+
+The contracts will be deployed using the same docker image as the one used for this procedure, which smooths out
+indeterminism in ink! contract compilation.

--- a/docker/most_builder.dockerfile
+++ b/docker/most_builder.dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/p6e8q1z1/ink-dev:1.7.0
+FROM rust:1.70
 
 RUN apt update
 RUN apt install -y curl make
@@ -11,6 +11,5 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-COPY * .
-# Trigger toolchain install
-RUN cargo check || true
+COPY rust-toolchain.toml .
+RUN cargo install cargo-contract --version 3.2.0


### PR DESCRIPTION
This includes modifying the dockerfile for the azero builder to be based on rust:1.70 instead of docker-ink-dev. Since rust:1.70 is an image maintained by an independent org on dockerhub it's a way to show "nothing up our sleeve" with this compilation.