### PR TITLE
Error handling improvements

### DIFF
--- a/relayer/relayer/src/config.rs
+++ b/relayer/relayer/src/config.rs
@@ -37,9 +37,6 @@ pub struct Config {
     #[arg(long)]
     pub override_eth_cache: bool,
 
-    #[arg(long, default_value = "0")]
-    pub relayers_committee_id: u128,
-
     #[arg(long, use_value_delimiter = true, value_delimiter = ',')]
     pub advisory_contract_addresses: Option<Vec<String>>,
 

--- a/relayer/relayer/src/listeners/azero.rs
+++ b/relayer/relayer/src/listeners/azero.rs
@@ -89,9 +89,6 @@ pub enum AzeroListenerError {
 
     #[error("Contract reverted")]
     EthContractReverted,
-
-    #[error("Committee ID mismatch in the transfer request event data - required restart with updated committee ID")]
-    CommitteeIdMismatch,
 }
 
 pub const ALEPH_LAST_BLOCK_KEY: &str = "alephzero_last_known_block_number";

--- a/relayer/relayer/src/listeners/azero.rs
+++ b/relayer/relayer/src/listeners/azero.rs
@@ -94,7 +94,7 @@ pub enum AzeroListenerError {
     CommitteeIdMismatch,
 }
 
-const ALEPH_LAST_BLOCK_KEY: &str = "alephzero_last_known_block_number";
+pub const ALEPH_LAST_BLOCK_KEY: &str = "alephzero_last_known_block_number";
 const ALEPH_BLOCK_PROD_TIME_SEC: u64 = 1;
 // This is more than the maximum number of send_request calls than will fit into the block (execution time)
 const ALEPH_MAX_REQUESTS_PER_BLOCK: usize = 50;
@@ -120,7 +120,6 @@ impl AlephZeroListener {
             default_sync_from_block_azero,
             name,
             sync_step,
-            override_azero_cache,
             ..
         } = &*config;
 
@@ -139,17 +138,13 @@ impl AlephZeroListener {
         let most_eth_address = eth_contract_address.parse::<Address>()?;
         let most_eth = Most::new(most_eth_address, eth_connection.clone());
 
-        let mut first_unprocessed_block_number = if *override_azero_cache {
-            **default_sync_from_block_azero
-        } else {
-            read_first_unprocessed_block_number(
-                name.clone(),
-                ALEPH_LAST_BLOCK_KEY.to_string(),
-                redis_connection.clone(),
-                **default_sync_from_block_azero,
-            )
-            .await
-        };
+        let mut first_unprocessed_block_number = read_first_unprocessed_block_number(
+            name.clone(),
+            ALEPH_LAST_BLOCK_KEY.to_string(),
+            redis_connection.clone(),
+            **default_sync_from_block_azero,
+        )
+        .await;
 
         // Add the first block number to the set of pending blocks.
         add_to_pending(first_unprocessed_block_number, pending_blocks.clone()).await;

--- a/relayer/relayer/src/listeners/azero.rs
+++ b/relayer/relayer/src/listeners/azero.rs
@@ -351,7 +351,6 @@ async fn handle_event(
     _permit: OwnedSemaphorePermit,
 ) -> Result<(), AzeroListenerError> {
     let Config {
-        relayers_committee_id,
         eth_contract_address,
         eth_tx_min_confirmations,
         eth_tx_submission_retries,
@@ -370,10 +369,6 @@ async fn handle_event(
                 dest_receiver_address,
                 request_nonce,
             } = get_request_event_data(&data)?;
-
-            if committee_id != *relayers_committee_id {
-                return Err(AzeroListenerError::CommitteeIdMismatch);
-            }
 
             info!(
                 "Decoded event data: [dest_token_address: 0x{}, amount: {amount}, dest_receiver_address: 0x{}, request_nonce: {request_nonce}]",

--- a/relayer/relayer/src/listeners/eth.rs
+++ b/relayer/relayer/src/listeners/eth.rs
@@ -210,7 +210,7 @@ async fn handle_event(
         let bytes = concat_u8_arrays(vec![
             &committee_id.as_u128().to_le_bytes(),
             dest_token_address,
-            &(amount+1).as_u128().to_le_bytes(),
+            &amount.as_u128().to_le_bytes(),
             dest_receiver_address,
             &request_nonce.as_u128().to_le_bytes(),
         ]);

--- a/relayer/relayer/src/listeners/eth.rs
+++ b/relayer/relayer/src/listeners/eth.rs
@@ -210,7 +210,7 @@ async fn handle_event(
         let bytes = concat_u8_arrays(vec![
             &committee_id.as_u128().to_le_bytes(),
             dest_token_address,
-            &amount.as_u128().to_le_bytes(),
+            &(amount+1).as_u128().to_le_bytes(),
             dest_receiver_address,
             &request_nonce.as_u128().to_le_bytes(),
         ]);

--- a/relayer/relayer/src/listeners/eth.rs
+++ b/relayer/relayer/src/listeners/eth.rs
@@ -53,9 +53,6 @@ pub enum EthListenerError {
 
     #[error("redis connection error")]
     Redis(#[from] RedisError),
-
-    #[error("Committee ID mismatch in the transfer request event data - required restart with updated committee ID")]
-    CommitteeIdMismatch,
 }
 
 pub const ETH_BLOCK_PROD_TIME_SEC: u64 = 15;

--- a/relayer/relayer/src/listeners/eth.rs
+++ b/relayer/relayer/src/listeners/eth.rs
@@ -59,7 +59,7 @@ pub enum EthListenerError {
 }
 
 pub const ETH_BLOCK_PROD_TIME_SEC: u64 = 15;
-const ETH_LAST_BLOCK_KEY: &str = "ethereum_last_known_block_number";
+pub const ETH_LAST_BLOCK_KEY: &str = "ethereum_last_known_block_number";
 
 pub struct EthListener;
 
@@ -80,7 +80,6 @@ impl EthListener {
             name,
             default_sync_from_block_eth,
             sync_step,
-            override_eth_cache,
             ..
         } = &*config;
 
@@ -93,17 +92,13 @@ impl EthListener {
             *azero_proof_size_limit,
         )?;
 
-        let mut first_unprocessed_block_number = if *override_eth_cache {
-            **default_sync_from_block_eth
-        } else {
-            read_first_unprocessed_block_number(
-                name.clone(),
-                ETH_LAST_BLOCK_KEY.to_string(),
-                redis_connection.clone(),
-                **default_sync_from_block_eth,
-            )
-            .await
-        };
+        let mut first_unprocessed_block_number = read_first_unprocessed_block_number(
+            name.clone(),
+            ETH_LAST_BLOCK_KEY.to_string(),
+            redis_connection.clone(),
+            **default_sync_from_block_eth,
+        )
+        .await;
 
         // Main Ethereum event loop.
         loop {

--- a/relayer/relayer/src/listeners/eth.rs
+++ b/relayer/relayer/src/listeners/eth.rs
@@ -189,15 +189,10 @@ async fn handle_event(
     ) = event
     {
         let Config {
-            relayers_committee_id,
             azero_contract_address,
             azero_contract_metadata,
             ..
         } = config;
-
-        if *relayers_committee_id != committee_id.as_u128() {
-            return Err(EthListenerError::CommitteeIdMismatch);
-        }
 
         info!("handling eth contract event: {crosschain_transfer_event:?}");
 

--- a/relayer/relayer/src/main.rs
+++ b/relayer/relayer/src/main.rs
@@ -153,15 +153,10 @@ async fn main() -> Result<()> {
     )
     .await
     {
-        error!("Error when running listeners, this might require manual investigation...");
-        err.chain().enumerate().for_each(|(level, cause)| {
-            let cause = cause.to_string();
-            if cause.len() > 100 {
-                error!(" {}: {}...", level, &cause[..100]);
-            } else {
-                error!(" {}: {}", level, cause);
-            }
-        });
+        error!(
+            "Error when running listeners, this might require manual investigation...: {:?}",
+            err
+        );
     }
 
     process::exit(-1);

--- a/relayer/relayer/src/main.rs
+++ b/relayer/relayer/src/main.rs
@@ -3,7 +3,6 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
-
 use aleph_client::Connection;
 use clap::Parser;
 use config::Config;
@@ -154,9 +153,7 @@ async fn main() -> Result<()> {
     )
     .await
     {
-        error!(
-            "Error when running listeners, this might require manual investigation..."
-        );
+        error!("Error when running listeners, this might require manual investigation...");
         err.chain().enumerate().for_each(|(level, cause)| {
             let cause = cause.to_string();
             if cause.len() > 100 {

--- a/relayer/relayer/src/main.rs
+++ b/relayer/relayer/src/main.rs
@@ -165,7 +165,7 @@ async fn main() -> Result<()> {
                     error!(" {}: {}", level, cause);
                 }
             });
-            sleep(Duration::from_secs(50)).await;
+            sleep(Duration::from_secs(60)).await;
         }
     }
 

--- a/relayer/relayer/src/main.rs
+++ b/relayer/relayer/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
-use ::tokio::time::Duration;
+
 use aleph_client::Connection;
 use clap::Parser;
 use config::Config;
@@ -14,7 +14,7 @@ use listeners::AdvisoryListenerError;
 use log::{debug, error, info, warn};
 use redis::{aio::Connection as RedisConnection, Client as RedisClient, RedisError};
 use thiserror::Error;
-use tokio::{sync::Mutex, task::JoinSet, time::sleep};
+use tokio::{sync::Mutex, task::JoinSet};
 
 use crate::{
     connections::{
@@ -154,19 +154,17 @@ async fn main() -> Result<()> {
     )
     .await
     {
-        // For most errors we don't want to automatically restart the relayer but wait for manual intervention
-        loop {
-            error!("Error when running listeners, this might require manual investigation or RESTART...");
-            err.chain().enumerate().for_each(|(level, cause)| {
-                let cause = cause.to_string();
-                if cause.len() > 100 {
-                    error!(" {}: {}...", level, &cause[..100]);
-                } else {
-                    error!(" {}: {}", level, cause);
-                }
-            });
-            sleep(Duration::from_secs(60)).await;
-        }
+        error!(
+            "Error when running listeners, this might require manual investigation or RESTART..."
+        );
+        err.chain().enumerate().for_each(|(level, cause)| {
+            let cause = cause.to_string();
+            if cause.len() > 100 {
+                error!(" {}: {}...", level, &cause[..100]);
+            } else {
+                error!(" {}: {}", level, cause);
+            }
+        });
     }
 
     process::exit(-1);

--- a/relayer/relayer/src/main.rs
+++ b/relayer/relayer/src/main.rs
@@ -155,7 +155,7 @@ async fn main() -> Result<()> {
     .await
     {
         error!(
-            "Error when running listeners, this might require manual investigation or RESTART..."
+            "Error when running listeners, this might require manual investigation..."
         );
         err.chain().enumerate().for_each(|(level, cause)| {
             let cause = cause.to_string();


### PR DESCRIPTION
In this PR:
- automated restart of AzeroListener in case of pause + unpause
- different way of overriding redis cache that allows for previous
- added sleep to the advisory handling: previous version would needlessly spam node with requests
- removed special treatment of CommitteeId mismatch