### PR TITLE
Unify most contracts

### DIFF
--- a/azero/contracts/most/lib.rs
+++ b/azero/contracts/most/lib.rs
@@ -745,6 +745,24 @@ pub mod most {
             Ok(())
         }
 
+        /// Transfer tokens from the bridge contract to a given account.
+        /// Used to recover user funds in case of a critical bug.
+        /// 
+        /// Can only be called by the contracts owner
+        #[ink(message)]
+        pub fn recover_psp22(
+            &mut self,
+            token: AccountId,
+            receiver: AccountId,
+            amount: u128,
+        ) -> Result<(), MostError> {
+            self.ensure_owner()?;
+
+            let token: ink::contract_ref!(PSP22) = token.into();
+            psp22.transfer(receiver, amount, vec![]);
+            Ok(())
+        }
+
         /// Is the bridge halted?
         #[ink(message)]
         pub fn is_halted(&self) -> Result<bool, MostError> {

--- a/azero/contracts/most/lib.rs
+++ b/azero/contracts/most/lib.rs
@@ -748,7 +748,7 @@ pub mod most {
 
         /// Transfer tokens from the bridge contract to a given account.
         /// Used to recover user funds in case of a critical bug.
-        /// 
+        ///
         /// Can only be called by the contracts owner
         #[ink(message)]
         pub fn recover_psp22(

--- a/azero/contracts/most/lib.rs
+++ b/azero/contracts/most/lib.rs
@@ -700,6 +700,7 @@ pub mod most {
             signature_threshold: u128,
         ) -> Result<(), MostError> {
             self.ensure_owner()?;
+            self.ensure_halted()?;
             Self::check_committee(&committee, signature_threshold)?;
 
             let mut data = self.data()?;
@@ -758,8 +759,8 @@ pub mod most {
         ) -> Result<(), MostError> {
             self.ensure_owner()?;
 
-            let token: ink::contract_ref!(PSP22) = token.into();
-            psp22.transfer(receiver, amount, vec![]);
+            let mut token: ink::contract_ref!(PSP22) = token.into();
+            token.transfer(receiver, amount, vec![])?;
             Ok(())
         }
 

--- a/azero/contracts/most/lib.rs
+++ b/azero/contracts/most/lib.rs
@@ -746,8 +746,7 @@ pub mod most {
             Ok(())
         }
 
-        /// Transfer tokens from the bridge contract to a given account.
-        /// Used to recover user funds in case of a critical bug.
+        /// Transfer PSP22 tokens from the bridge contract to a given account.
         ///
         /// Can only be called by the contracts owner
         #[ink(message)]
@@ -761,6 +760,21 @@ pub mod most {
 
             let mut token: ink::contract_ref!(PSP22) = token.into();
             token.transfer(receiver, amount, vec![])?;
+            Ok(())
+        }
+
+        /// Transfer AZERO tokens from the bridge contract to a given account.
+        ///
+        /// Can only be called by the contracts owner
+        #[ink(message)]
+        pub fn recover_azero(
+            &mut self,
+            receiver: AccountId,
+            amount: u128,
+        ) -> Result<(), MostError> {
+            self.ensure_owner()?;
+
+            self.env().transfer(receiver, amount)?;
             Ok(())
         }
 

--- a/azero/contracts/tests/lib.rs
+++ b/azero/contracts/tests/lib.rs
@@ -790,6 +790,10 @@ mod e2e {
 
         let previous_committee_size = guardian_ids().len();
 
+        most_set_halted(&mut client, &alice(), most_address, true)
+            .await
+            .expect("can set halted");
+
         most_set_committee(
             &mut client,
             &alice(),
@@ -799,6 +803,10 @@ mod e2e {
         )
         .await
         .expect("can set committee");
+
+        most_set_halted(&mut client, &alice(), most_address, false)
+            .await
+            .expect("can set halted");
 
         let member_id = guardian_ids()[0];
 
@@ -919,6 +927,10 @@ mod e2e {
     fn committee_change(mut client: ink_e2e::Client<C, E>) {
         let (most_address, token_address) = setup_default_most_and_token(&mut client, true).await;
 
+        most_set_halted(&mut client, &alice(), most_address, true)
+            .await
+            .expect("can set halted");
+
         most_set_committee(
             &mut client,
             &alice(),
@@ -940,6 +952,10 @@ mod e2e {
         )
         .await
         .expect("can set committee");
+
+        most_set_halted(&mut client, &alice(), most_address, false)
+            .await
+            .expect("can set halted");
 
         let new_committee_id = 2;
 

--- a/eth/contracts/Most.sol
+++ b/eth/contracts/Most.sol
@@ -295,7 +295,7 @@ contract Most is
     function setCommittee(
         address[] calldata _committee,
         uint256 _signatureThreshold
-    ) external onlyOwner {
+    ) external onlyOwner whenPaused {
         ++committeeId;
         _setCommittee(_committee, _signatureThreshold);
         emit CommitteeUpdated(committeeId);

--- a/eth/contracts/Most.sol
+++ b/eth/contracts/Most.sol
@@ -91,6 +91,7 @@ contract Most is
 
         __Ownable_init(owner);
         __Pausable_init();
+        _pause();
     }
 
     /// @dev required by the OZ UUPS module

--- a/eth/scripts/3_setup_bridge_contracts.js
+++ b/eth/scripts/3_setup_bridge_contracts.js
@@ -55,8 +55,6 @@ async function addTokenPair(
   );
 
   const iface = await new ethers.Interface([
-    "function pause()",
-    "function unpause()",
     "function addPair(bytes32 from, bytes32 to)",
   ]);
 
@@ -68,17 +66,7 @@ async function addTokenPair(
   const transactions = [
     {
       to: mostContract.address,
-      data: await iface.encodeFunctionData("pause", []),
-      value: 0,
-    },
-    {
-      to: mostContract.address,
       data: addPaircalldata,
-      value: 0,
-    },
-    {
-      to: mostContract.address,
-      data: await iface.encodeFunctionData("unpause", []),
       value: 0,
     },
   ];
@@ -104,6 +92,47 @@ async function addTokenPair(
     ethTokenAddressBytes,
     "=>",
     await mostContract.supportedPairs(ethTokenAddressBytes),
+  );
+}
+
+async function unpauseMost(
+  mostContract,
+  safeInstances,
+) {
+  console.log(
+    "Unpausing Most:"
+  );
+
+  const iface = await new ethers.Interface([
+    "function unpause()",
+  ]);
+
+  const transactions = [
+    {
+      to: mostContract.address,
+      data: await iface.encodeFunctionData("unpause", []),
+      value: 0,
+    },
+  ];
+
+  console.log("creating a Safe transactions:", transactions);
+
+  const safeTransaction = await safeInstances[0].createTransaction({
+    transactions,
+  });
+  const safeTxHash = await safeInstances[0].getTransactionHash(safeTransaction);
+
+  console.log("safeTxHash", safeTxHash);
+
+  for (const safeInstance of safeInstances) {
+    await signSafeTransaction(safeInstance, safeTxHash);
+  }
+
+  // execute safe tx
+  await executeSafeTransaction(safeInstances[0], safeTransaction);
+
+  console.log(
+    "Most is now unpaused."
   );
 }
 
@@ -186,6 +215,9 @@ async function main() {
       safeSdk0,
       safeSdk1,
     ]);
+
+    // --- unpause most
+    await unpauseMost(most, [safeSdk0, safeSdk1]);
   }
 
   // -- update migrations

--- a/eth/scripts/3_setup_bridge_contracts.js
+++ b/eth/scripts/3_setup_bridge_contracts.js
@@ -95,17 +95,10 @@ async function addTokenPair(
   );
 }
 
-async function unpauseMost(
-  mostContract,
-  safeInstances,
-) {
-  console.log(
-    "Unpausing Most:"
-  );
+async function unpauseMost(mostContract, safeInstances) {
+  console.log("Unpausing Most:");
 
-  const iface = await new ethers.Interface([
-    "function unpause()",
-  ]);
+  const iface = await new ethers.Interface(["function unpause()"]);
 
   const transactions = [
     {
@@ -131,9 +124,7 @@ async function unpauseMost(
   // execute safe tx
   await executeSafeTransaction(safeInstances[0], safeTransaction);
 
-  console.log(
-    "Most is now unpaused."
-  );
+  console.log("Most is now unpaused.");
 }
 
 // signing with on-chain signatures

--- a/eth/test/BenchmarkMost.js
+++ b/eth/test/BenchmarkMost.js
@@ -36,7 +36,6 @@ describe("MostBenchmark", function () {
     let tokenAddressBytes32 = addressToBytes32(tokenAddress);
 
     // Add pair of linked contracts
-    await most.pause();
     await most.addPair(tokenAddressBytes32, azContract, { from: accounts[0] });
     await most.addPair(addressToBytes32(wethAddress), azContract2, {
       from: accounts[0],

--- a/eth/test/Most.js
+++ b/eth/test/Most.js
@@ -396,7 +396,9 @@ describe("Most", function () {
       await token.transfer(await most.getAddress(), TOKEN_AMOUNT * 2);
 
       // Rotate committee
+      await most.connect(accounts[0]).pause();
       await most.connect(accounts[0]).setCommittee(accounts.slice(3, 10), 5);
+      await most.connect(accounts[0]).unpause();
 
       await most
         .connect(accounts[2])

--- a/eth/test/Most.js
+++ b/eth/test/Most.js
@@ -101,6 +101,7 @@ describe("Most", function () {
       },
     );
     const mostAddress = await most.getAddress();
+    await most.unpause();
 
     const Token = await ethers.getContractFactory("Token");
     const token = await Token.deploy(
@@ -184,7 +185,7 @@ describe("Most", function () {
     });
 
     it("Transfers tokens to Most", async () => {
-      const { most, token, mostAddress, wethAddress, weth } = await loadFixture(
+      const { most, mostAddress, wethAddress, weth } = await loadFixture(
         deployEightGuardianMostFixture,
       );
       await most.pause();
@@ -196,7 +197,7 @@ describe("Most", function () {
     });
 
     it("Emits correct event", async () => {
-      const { most, token, mostAddress, wethAddress } = await loadFixture(
+      const { most, wethAddress } = await loadFixture(
         deployEightGuardianMostFixture,
       );
       await most.pause();


### PR DESCRIPTION
- Makes solidity version halted after deployment
- Adds funds recovery function to ink! version

Additionally adds requirement for contract halt/pause for committee rotations. 