### PR TITLE
Adjust deployment scripts for testnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ deploy-eth-live: compile-eth
 	cd eth && \
 	npx hardhat run --network $(NETWORK) scripts/deploy_bridge_live.js
 
+.PHONY: deploy-live
+deploy-live: # Deploy azero and eth contracts on a live network (testnet or mainnet)
+deploy-live: deploy-azero setup-azero deploy-eth-live
+
 .PHONY: verify-eth
 verify-eth: # Post verified eth sources of a contract to etherscan
 verify-eth:

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,18 @@ deploy-eth: compile-eth
 	npx hardhat run --network $(NETWORK) scripts/1_deploy_gnosis_safe.js && \
 	npx hardhat run --network $(NETWORK) scripts/2_deploy_bridge_contracts.js
 
+.PHONY: deploy-eth-live
+deploy-eth-live: # Deploy only the MOST contract on a live ethrereum network (tesnet or mainnet)
+deploy-eth-live: compile-eth
+	cd eth && \
+	npx hardhat run --network $(NETWORK) scripts/deploy_bridge_live.js
+
+.PHONY: verify-eth
+verify-eth: # Post verified eth sources of a contract to etherscan
+verify-eth:
+	cd eth && \
+	npx hardhat verify --network $(NETWORK) $(CONTRACT)
+
 .PHONY: setup-eth
 setup-eth: # Setup eth contracts
 setup-eth: compile-eth

--- a/azero/env/dev.json
+++ b/azero/env/dev.json
@@ -5,13 +5,26 @@
     "5Dfis6XL8J2P6JHUnUtArnFWndn62SydeP8ee8sG2ky9nfm9",
     "5F4H97f7nQovyrbiq4ZetaaviNwThSVcFobcA5aGab6167dK"
   ],
-  "contracts_owner": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-  "gas_price_oracle_owner": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
   "deployer_seed": "//Alice",
   "signature_threshold": 2,
   "pocket_money": 1000000000000,
   "min_gas_price": 60000000,
   "max_gas_price": 450000000,
   "default_gas_price": 180000000,
-  "relay_gas_usage": 450000
+  "relay_gas_usage": 450000,
+  "dev": true,
+  "tokens": [
+    {
+      "symbol": "wETH",
+      "name": "Wrapped Ether",
+      "decimals": 18,
+      "checkAddress": "weth"
+    },
+    {
+      "symbol": "USDT",
+      "name": "Tether",
+      "decimals": 6,
+      "checkAddress": "usdt"
+    }
+  ]
 }

--- a/azero/env/testnet.json.example
+++ b/azero/env/testnet.json.example
@@ -1,5 +1,5 @@
 {
-  "ws_node": "wss://ws-fe-bridgenet.dev.azero.dev",
+  "ws_node": "wss://ws.test.azero.dev",
   "relayers": [
     "5GBNeWRhZc2jXu7D55rBimKYDk8PGk8itRYFTPfC8RJLKG5o",
     "5Dfis6XL8J2P6JHUnUtArnFWndn62SydeP8ee8sG2ky9nfm9",
@@ -12,19 +12,19 @@
   "max_gas_price": 450000000,
   "default_gas_price": 180000000,
   "relay_gas_usage": 450000,
-  "dev": true,
+  "dev": false,
   "tokens": [
     {
       "symbol": "wETH",
       "name": "Wrapped Ether",
       "decimals": 18,
-      "checkAddress": "weth"
+      "ethAddress": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14"
     },
     {
-      "symbol": "USDT",
-      "name": "Tether",
+      "symbol": "wAT",
+      "name": "Wrapped Aleph Tether",
       "decimals": 6,
-      "checkAddress": "usdt"
+      "ethAddress": "0xa781D55E5603Bb60b49cd219863D8102523E7aff"
     }
   ]
 }

--- a/azero/scripts/1_deploy.ts
+++ b/azero/scripts/1_deploy.ts
@@ -12,7 +12,7 @@ import {
   import_env,
   storeAddresses,
   Addresses,
-  import_eth_addresses
+  import_eth_addresses,
 } from "./utils";
 import "dotenv/config";
 import "@polkadot/api-augment";
@@ -61,7 +61,7 @@ async function main(): Promise<void> {
     max_gas_price,
     default_gas_price,
     tokens,
-    dev
+    dev,
   } = config;
 
   const wsProvider = new WsProvider(ws_node);
@@ -179,9 +179,9 @@ async function main(): Promise<void> {
     const { address } = await deployToken(tokenArgs, api, deployer);
     console.log(token.symbol, "address:", address);
 
-    let ethAddress = token.checkAddress ?
-      ethAddresses[token.checkAddress] :
-      token.ethAddress!;
+    let ethAddress = token.checkAddress
+      ? ethAddresses[token.checkAddress]
+      : token.ethAddress!;
 
     tokenAddresses.push([ethAddress, address]);
   }

--- a/azero/scripts/utils.ts
+++ b/azero/scripts/utils.ts
@@ -12,11 +12,10 @@ import {
 
 export type Addresses = {
   most: string;
-  weth: string;
-  usdt: string;
   oracle: string;
   advisory: string;
   migrations: string;
+  tokens: [string, string][];
 };
 
 /**

--- a/eth/hardhat.config.js
+++ b/eth/hardhat.config.js
@@ -111,10 +111,11 @@ if (SEPOLIA_KEY) {
     url: "https://ethereum-sepolia-rpc.publicnode.com",
     accounts: [SEPOLIA_KEY],
     deploymentConfig: {
-      governanceIds: [
+      guardianIds: [
         "0xc4E0B92Df2DE77C077D060e49ec63DC196980716", // sepolia account address corresponding to SEPOLIA_KEY
       ],
-      governanceThreshold: 1,
+      threshold: 1,
+      weth: "0xfff9976782d46cc05630d1f6ebab18b2324d6b14",
     },
   };
 }

--- a/eth/scripts/3_setup_bridge_contracts.js
+++ b/eth/scripts/3_setup_bridge_contracts.js
@@ -198,10 +198,7 @@ async function main() {
     console.log("signer1", signer1.address);
 
     for (let [ethAddress, azeroAddress] of azeroContracts.tokens) {
-      await addTokenPair(ethAddress, azeroAddress, most, [
-        safeSdk0,
-        safeSdk1,
-      ]);
+      await addTokenPair(ethAddress, azeroAddress, most, [safeSdk0, safeSdk1]);
     }
 
     // --- unpause most

--- a/eth/scripts/3_setup_bridge_contracts.js
+++ b/eth/scripts/3_setup_bridge_contracts.js
@@ -197,15 +197,12 @@ async function main() {
     console.log("signer0", signer0.address);
     console.log("signer1", signer1.address);
 
-    await addTokenPair(addresses.weth, azeroContracts.weth, most, [
-      safeSdk0,
-      safeSdk1,
-    ]);
-
-    await addTokenPair(addresses.usdt, azeroContracts.usdt, most, [
-      safeSdk0,
-      safeSdk1,
-    ]);
+    for (let [ethAddress, azeroAddress] of azeroContracts.tokens) {
+      await addTokenPair(ethAddress, azeroAddress, most, [
+        safeSdk0,
+        safeSdk1,
+      ]);
+    }
 
     // --- unpause most
     await unpauseMost(most, [safeSdk0, safeSdk1]);

--- a/eth/scripts/deploy_bridge_live.js
+++ b/eth/scripts/deploy_bridge_live.js
@@ -1,0 +1,67 @@
+const fs = require('node:fs');
+const { u8aToHex } = require("@polkadot/util");
+const { Keyring } = require("@polkadot/keyring");
+const { network, ethers, upgrades } = require('hardhat');
+
+const azeroContracts = require("../../azero/addresses.json");
+
+async function main() {
+	const signers = await ethers.getSigners();
+	const accounts = signers.map(s => s.address);
+	const config = network.config.deploymentConfig;
+
+	console.log('Using', accounts[0], 'as the transaction signer');
+
+	const Most = await ethers.getContractFactory('Most');
+	console.log('Deploying Most...');
+
+	let weth = ethers.getAddress(config.weth);
+
+	const most = await upgrades.deployProxy(
+		Most,
+		[
+			config.guardianIds,
+			config.threshold,
+			accounts[0],
+			weth,
+		],
+		{
+			initializer: 'initialize',
+			kind: 'uups',
+		},
+	);
+	await most.waitForDeployment();
+	console.log('Most deployed to:', most.target);
+
+	for (let [ethAddress, azeroAddress] of azeroContracts.tokens) {
+		console.log('Adding pair', ethAddress, azeroAddress);
+
+		let ethAddressBytes = ethers.zeroPadValue(
+			ethers.getBytes(ethAddress),
+			32,
+		);
+
+		let azeroAddressBytes = u8aToHex(
+			new Keyring({ type: "sr25519" }).decodeAddress(azeroAddress),
+		);
+
+		let tx = await most.addPair(ethAddressBytes, azeroAddressBytes);
+		await tx.wait();
+	}
+
+	addresses = {
+		most: most.target,
+	};
+
+	console.log(addresses);
+	fs.writeFileSync('addresses.json', JSON.stringify(addresses));
+
+	console.log('Done');
+	// NOTE: neccessary because script hangs in CI
+	process.exit(0);
+}
+
+main().catch(error => {
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/eth/scripts/deploy_bridge_live.js
+++ b/eth/scripts/deploy_bridge_live.js
@@ -1,67 +1,59 @@
-const fs = require('node:fs');
+const fs = require("node:fs");
 const { u8aToHex } = require("@polkadot/util");
 const { Keyring } = require("@polkadot/keyring");
-const { network, ethers, upgrades } = require('hardhat');
+const { network, ethers, upgrades } = require("hardhat");
 
 const azeroContracts = require("../../azero/addresses.json");
 
 async function main() {
-	const signers = await ethers.getSigners();
-	const accounts = signers.map(s => s.address);
-	const config = network.config.deploymentConfig;
+  const signers = await ethers.getSigners();
+  const accounts = signers.map((s) => s.address);
+  const config = network.config.deploymentConfig;
 
-	console.log('Using', accounts[0], 'as the transaction signer');
+  console.log("Using", accounts[0], "as the transaction signer");
 
-	const Most = await ethers.getContractFactory('Most');
-	console.log('Deploying Most...');
+  const Most = await ethers.getContractFactory("Most");
+  console.log("Deploying Most...");
 
-	let weth = ethers.getAddress(config.weth);
+  let weth = ethers.getAddress(config.weth);
 
-	const most = await upgrades.deployProxy(
-		Most,
-		[
-			config.guardianIds,
-			config.threshold,
-			accounts[0],
-			weth,
-		],
-		{
-			initializer: 'initialize',
-			kind: 'uups',
-		},
-	);
-	await most.waitForDeployment();
-	console.log('Most deployed to:', most.target);
+  const most = await upgrades.deployProxy(
+    Most,
+    [config.guardianIds, config.threshold, accounts[0], weth],
+    {
+      initializer: "initialize",
+      kind: "uups",
+    },
+  );
+  await most.waitForDeployment();
+  console.log("Most deployed to:", most.target);
 
-	for (let [ethAddress, azeroAddress] of azeroContracts.tokens) {
-		console.log('Adding pair', ethAddress, azeroAddress);
+  for (let [ethAddress, azeroAddress] of azeroContracts.tokens) {
+    console.log("Adding pair", ethAddress, azeroAddress);
 
-		let ethAddressBytes = ethers.zeroPadValue(
-			ethers.getBytes(ethAddress),
-			32,
-		);
+    let ethAddressBytes = ethers.zeroPadValue(ethers.getBytes(ethAddress), 32);
 
-		let azeroAddressBytes = u8aToHex(
-			new Keyring({ type: "sr25519" }).decodeAddress(azeroAddress),
-		);
+    let azeroAddressBytes = u8aToHex(
+      new Keyring({ type: "sr25519" }).decodeAddress(azeroAddress),
+    );
 
-		let tx = await most.addPair(ethAddressBytes, azeroAddressBytes);
-		await tx.wait();
-	}
+    let tx = await most.addPair(ethAddressBytes, azeroAddressBytes);
+    await tx.wait();
+  }
 
-	addresses = {
-		most: most.target,
-	};
+  addresses = {
+    most: most.target,
+  };
 
-	console.log(addresses);
-	fs.writeFileSync('addresses.json', JSON.stringify(addresses));
+  console.log(addresses);
+  fs.writeFileSync("addresses.json", JSON.stringify(addresses));
 
-	console.log('Done');
-	// NOTE: neccessary because script hangs in CI
-	process.exit(0);
+  console.log("Done");
+  // NOTE: neccessary because script hangs in CI
+  process.exit(0);
 }
 
-main().catch(error => {
-	console.error(error);
-	process.exitCode = 1;
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
* Adds a completely new script for ETH - the existing one is entangled with Gnosis Safe deployment, which I don't think we need.
* Tweaks the Aleph Zero deployment script so that it can work with existing tokens with known addresses.

Instructions for deployment with these:

* Prepare config based on azero/env/testnet.json.example -> azero/env/testnet.json
* Adjust deploymentConfig for sepolia in eth/hardhat.config.js
* AZERO_ENV=testnet SEPOLIA_KEY=[private key] NETWORK=sepolia make deploy-live
* Get the address and verify the contract on etherscan
    * SEPOLIA_KEY=[private key] NETWORK=sepolia CONTRACT=[address] make verify-eth

