### PR TITLE
Fix arguments order for token contracts

### DIFF
--- a/azero/scripts/1_deploy.ts
+++ b/azero/scripts/1_deploy.ts
@@ -170,8 +170,8 @@ async function main(): Promise<void> {
     const initialSupply = 0;
     const tokenArgs: TokenArgs = [
       initialSupply,
-      token.symbol,
       token.name,
+      token.symbol,
       token.decimals,
       minterBurner,
     ];


### PR DESCRIPTION
Name and symbol arguments are swapped:
https://github.com/Cardinal-Cryptography/most/blob/master/azero/contracts/token/lib.rs#L62-L63