### PR TITLE
Feature/blacklisted requests

### DIFF
--- a/relayer/relayer/src/config.rs
+++ b/relayer/relayer/src/config.rs
@@ -1,5 +1,7 @@
 use std::{cmp::max, ops::Deref, str::FromStr};
 
+use ethers::core::types::H256;
+
 #[derive(Debug, Clone)]
 pub struct SyncFromBlock(u32);
 
@@ -36,6 +38,10 @@ pub struct Config {
 
     #[arg(long)]
     pub override_eth_cache: bool,
+
+    /// Optional list of hex encoded request hashes to skip from processing
+    #[arg(long, use_value_delimiter = true, value_delimiter = ',')]
+    pub blacklisted_requests: Option<Vec<H256>>,
 
     #[arg(long, use_value_delimiter = true, value_delimiter = ',')]
     pub advisory_contract_addresses: Option<Vec<String>>,

--- a/relayer/relayer/src/handlers/azero.rs
+++ b/relayer/relayer/src/handlers/azero.rs
@@ -107,7 +107,7 @@ impl AlephZeroEventHandler {
 
                 if let Some(blacklist) = blacklisted_requests {
                     if blacklist.contains(&H256::from_str(&request_hash_hex)?) {
-                        warn!("Skipping blacklisted request: {request_hash_hex}");
+                        warn!("Skipping blacklisted request: 0x{request_hash_hex}");
                         return Ok(());
                     }
                 }

--- a/relayer/relayer/src/handlers/azero.rs
+++ b/relayer/relayer/src/handlers/azero.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 use aleph_client::contract::event::ContractEvent;
 use ethers::{
     abi::{self, Token},
-    core::types::Address,
+    core::types::{Address, H256},
     prelude::{ContractCall, ContractError},
     providers::{Middleware, ProviderError},
     types::{BlockNumber, U64},
@@ -64,6 +64,7 @@ impl AlephZeroEventHandler {
             eth_contract_address,
             eth_tx_min_confirmations,
             eth_tx_submission_retries,
+            blacklisted_requests,
             ..
         } = &*config;
 
@@ -103,6 +104,13 @@ impl AlephZeroEventHandler {
                 let request_hash_hex = hex::encode(request_hash);
 
                 info!("hashed event encoding: 0x{}", request_hash_hex);
+
+                if let Some(blacklist) = blacklisted_requests {
+                    if blacklist.contains(&H256::from_str(&request_hash_hex)?) {
+                        warn!("Skipping blacklisted request: {request_hash_hex}");
+                        return Ok(());
+                    }
+                }
 
                 let address = eth_contract_address.parse::<Address>()?;
                 let contract = Most::new(address, eth_signed_connection.clone());

--- a/relayer/relayer/src/handlers/eth.rs
+++ b/relayer/relayer/src/handlers/eth.rs
@@ -1,7 +1,8 @@
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
-use ethers::utils::keccak256;
+use ethers::{core::types::H256, utils::keccak256};
 use log::{debug, error, info, trace, warn};
+use rustc_hex::FromHexError;
 use thiserror::Error;
 use tokio::{
     select,
@@ -33,6 +34,9 @@ pub enum EthereumEventHandlerError {
         dest_receiver_address: String,
         request_nonce: u128,
     },
+
+    #[error("error when decoding a hex encoded string")]
+    FromHex(#[from] FromHexError),
 }
 
 pub struct EthereumEventHandler;
@@ -46,6 +50,7 @@ impl EthereumEventHandler {
         let Config {
             azero_contract_address,
             azero_contract_metadata,
+            blacklisted_requests,
             ..
         } = config;
 
@@ -74,7 +79,15 @@ impl EthereumEventHandler {
             trace!("event concatenated bytes: {bytes:?}");
 
             let request_hash = keccak256(bytes);
-            info!("hashed event encoding: {request_hash:?}");
+            let request_hash_hex = hex::encode(request_hash);
+            info!("hashed event encoding: 0x{}", request_hash_hex);
+
+            if let Some(blacklist) = blacklisted_requests {
+                if blacklist.contains(&H256::from_str(&request_hash_hex)?) {
+                    warn!("Skipping blacklisted request: {request_hash_hex}");
+                    return Ok(());
+                }
+            }
 
             let contract = MostInstance::new(
                 azero_contract_address,

--- a/relayer/relayer/src/handlers/eth.rs
+++ b/relayer/relayer/src/handlers/eth.rs
@@ -84,7 +84,7 @@ impl EthereumEventHandler {
 
             if let Some(blacklist) = blacklisted_requests {
                 if blacklist.contains(&H256::from_str(&request_hash_hex)?) {
-                    warn!("Skipping blacklisted request: {request_hash_hex}");
+                    warn!("Skipping blacklisted request: 0x{request_hash_hex}");
                     return Ok(());
                 }
             }


### PR DESCRIPTION

```
cargo run --bin relayer -- --blacklisted-requests "0x9343fc5ea817d894cc5c15fc90394e1bb69fe88db8e590384a50cc5cc175dac3"  ... --dev
```


```
[2024-04-15T14:45:08Z INFO  relayer::handlers::azero] Decoded event data: [dest_token_address: 0x000000000000000000000000cd15482de8331a16e20b8a7e97130c735fbc8dcf, amount: 1000000000000, dest_receiver_address: 0x000000000000000000000000ee88da44b4901d7f86970c52dc5139af80c83edd, request_nonce: 1]
[2024-04-15T14:45:08Z INFO  relayer::handlers::azero] hashed event encoding: 0x9343fc5ea817d894cc5c15fc90394e1bb69fe88db8e590384a50cc5cc175dac3
[2024-04-15T14:45:08Z WARN  relayer::handlers::azero] Skipping blacklisted request: 9343fc5ea817d894cc5c15fc90394e1bb69fe88db8e590384a50cc5cc175dac3
```