### PR TITLE
Feature/better logs

### DIFF
--- a/azero/scripts/bridge_weth.ts
+++ b/azero/scripts/bridge_weth.ts
@@ -5,7 +5,7 @@ import {
   import_env,
   import_azero_addresses,
   accountIdToHex,
-  hexToBytes,
+  hexToBytes
 } from "./utils";
 import { ethers } from "ethers";
 
@@ -65,26 +65,35 @@ async function main(): Promise<void> {
 
   // send request
   const most = new Most(most_azero, signer, api);
+
+  let srcTokenAddress = hexToBytes(accountIdToHex(weth_azero));
+
+  let destReceiverAddress = hexToBytes(
+    ethers.zeroPadValue(ethers.getBytes(receiver), 32),
+  );
+
+  const fee = 1000000000000000;
+
   console.log(
     "Requesting transfer of",
     amount,
     "units of",
     weth_azero,
+    "[",
+    accountIdToHex(weth_azero),
+    "]",
     "to",
     receiver,
-  );
-
-  let srcTokenAddress = hexToBytes(accountIdToHex(weth_azero));
-  let destReceiverAddress = hexToBytes(
+    "[",
     ethers.zeroPadValue(ethers.getBytes(receiver), 32),
+    "]",
   );
 
-  const value = 1000000000000000;
   let tx = await most.tx.sendRequest(
     srcTokenAddress,
     amount,
     destReceiverAddress,
-    { value },
+    { value: fee },
   );
 
   console.log(

--- a/azero/scripts/bridge_weth.ts
+++ b/azero/scripts/bridge_weth.ts
@@ -5,7 +5,7 @@ import {
   import_env,
   import_azero_addresses,
   accountIdToHex,
-  hexToBytes
+  hexToBytes,
 } from "./utils";
 import { ethers } from "ethers";
 

--- a/azero/scripts/utils.ts
+++ b/azero/scripts/utils.ts
@@ -79,6 +79,10 @@ export function hexToBytes(hex: string): number[] {
   return Array.from(u8array);
 }
 
+export function bytesToHex(bytes: number[]): string {
+  return u8aToHex(new Uint8Array(bytes));
+}
+
 export function accountIdToHex(accountId: string): string {
   return u8aToHex(new Keyring({ type: "sr25519" }).decodeAddress(accountId));
 }

--- a/relayer/relayer/src/contracts/azero.rs
+++ b/relayer/relayer/src/contracts/azero.rs
@@ -239,6 +239,7 @@ impl MostInstance {
     }
 }
 
+#[derive(Debug)]
 pub struct CrosschainTransferRequestData {
     pub committee_id: u128,
     pub dest_token_address: [u8; 32],

--- a/relayer/relayer/src/handlers/azero.rs
+++ b/relayer/relayer/src/handlers/azero.rs
@@ -87,7 +87,7 @@ impl AlephZeroEventHandler {
                 debug!("Handling azero contract event: {crosschain_transfer_event:?}");
 
                 info!(
-                    "Decoded event data: [dest_token_address: 0x{}, amount: {amount}, dest_receiver_address: 0x{}, request_nonce: {request_nonce}, committee_id: {committee_id}]",
+                    "Decoded event data: [dest_token_address: {}, amount: {amount}, dest_receiver_address: {}, request_nonce: {request_nonce}, committee_id: {committee_id}]",
                     hex::encode(dest_token_address),
                     hex::encode(dest_receiver_address)
                 );

--- a/relayer/relayer/src/handlers/azero.rs
+++ b/relayer/relayer/src/handlers/azero.rs
@@ -9,7 +9,7 @@ use ethers::{
     types::{BlockNumber, U256, U64},
     utils::keccak256,
 };
-use log::{debug, error, info, warn};
+use log::{debug, error, info, trace, warn};
 use thiserror::Error;
 use tokio::{
     select,
@@ -76,7 +76,7 @@ impl AlephZeroEventHandler {
                 let data = event.data;
 
                 // decode event data
-                let CrosschainTransferRequestData {
+                let crosschain_transfer_event @ CrosschainTransferRequestData {
                     committee_id,
                     dest_token_address,
                     amount,
@@ -84,8 +84,10 @@ impl AlephZeroEventHandler {
                     request_nonce,
                 } = get_request_event_data(&data)?;
 
+                debug!("Handling azero contract event: {crosschain_transfer_event:?}");
+
                 info!(
-                    "Decoded event data: [dest_token_address: 0x{}, amount: {amount}, dest_receiver_address: 0x{}, request_nonce: {request_nonce}]",
+                    "Decoded event data: [dest_token_address: 0x{}, amount: {amount}, dest_receiver_address: 0x{}, request_nonce: {request_nonce}, committee_id: {committee_id}]",
                     hex::encode(dest_token_address),
                     hex::encode(dest_receiver_address)
                 );
@@ -101,12 +103,13 @@ impl AlephZeroEventHandler {
                     Token::Uint(request_nonce.into()),
                 ]);
 
-                debug!("ABI event encoding: 0x{}", hex::encode(bytes.clone()));
+                trace!("ABI compliant concatenated event bytes {bytes:?}");
 
                 let request_hash = keccak256(bytes);
-                let request_hash_hex = hex::encode(request_hash);
+                debug!("Hashed event data: {request_hash:?}");
 
-                info!("hashed event encoding: 0x{}", request_hash_hex);
+                let request_hash_hex = hex::encode(request_hash);
+                info!("Request hash hex encoding: 0x{}", request_hash_hex);
 
                 if let Some(blacklist) = blacklisted_requests {
                     if blacklist.contains(&H256::from_str(&request_hash_hex)?) {
@@ -125,7 +128,7 @@ impl AlephZeroEventHandler {
                 )
                 .await?
                 {
-                    info!("Guardian signature for {request_hash:?} not needed - request from a past committee");
+                    info!("Guardian signature for 0x{request_hash_hex} not needed - request from a past committee");
                     return Ok(());
                 }
 
@@ -138,7 +141,7 @@ impl AlephZeroEventHandler {
                     .block(BlockNumber::Finalized)
                     .await?
                 {
-                    info!("Request with nonce {} not yet finalized.", request_nonce);
+                    info!("Request 0x{request_hash_hex} not yet finalized.");
 
                     if !contract
                         .needs_signature(
@@ -163,15 +166,13 @@ impl AlephZeroEventHandler {
                         request_nonce.into(),
                     );
 
-                    debug!("Dry-running tx with nonce {}", request_nonce);
+                    debug!("Dry-running tx for request 0x{request_hash_hex}");
 
                     // Dry-run the tx to check for potential reverts.
                     call.clone().gas(config.eth_gas_limit).call().await?;
 
                     info!(
-                        "Sending tx with nonce {} to the Ethereum network and waiting for {} confirmations.",
-                        request_nonce,
-                        eth_tx_min_confirmations
+                        "Sending tx for request 0x{request_hash_hex} to the Ethereum network and waiting for {eth_tx_min_confirmations} confirmations."
                     );
 
                     let receipt = call
@@ -190,15 +191,15 @@ impl AlephZeroEventHandler {
                     // Check if the tx reverted.
                     if tx_status == Some(U64::from(0)) {
                         warn!(
-                        "Tx with nonce {request_nonce} has been sent to the Ethereum network: {tx_hash:?} but it reverted."
+                        "Tx for request 0x{request_hash_hex} has been sent to the Ethereum network: {tx_hash:?} but it reverted."
                     );
                         return Err(AlephZeroEventHandlerError::EthContractReverted);
                     }
 
-                    info!("Tx with nonce {request_nonce} has been sent to the Ethereum network: {tx_hash:?} and received {eth_tx_min_confirmations} confirmations.");
+                    info!("Tx for request 0x{request_hash_hex} has been sent to the Ethereum network: {tx_hash:?} and received {eth_tx_min_confirmations} confirmations.");
                 }
 
-                info!("Guardian signature for {request_hash:?} no longer needed");
+                info!("Guardian signature for 0x{request_hash_hex} no longer needed");
             }
         }
         Ok(())

--- a/relayer/relayer/src/handlers/eth.rs
+++ b/relayer/relayer/src/handlers/eth.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, sync::Arc};
 
-use aleph_client::{AsConnection, SignedConnectionApi};
+use aleph_client::{AccountId, AsConnection, SignedConnectionApi};
 use ethers::{core::types::H256, utils::keccak256};
 use log::{debug, error, info, trace, warn};
 use rustc_hex::FromHexError;
@@ -69,7 +69,13 @@ impl EthereumEventHandler {
             },
         ) = event
         {
-            info!("handling eth contract event: {crosschain_transfer_event:?}");
+            debug!("Handling eth contract event: {crosschain_transfer_event:?}");
+
+            info!(
+                    "Decoded event data: [dest_token_address: 0x{}, amount: {amount}, dest_receiver_address: 0x{}, request_nonce: {request_nonce}, committee_id: {committee_id}]",
+                    AccountId::from(dest_token_address),
+                    AccountId::from(dest_receiver_address)
+                );
 
             // concat bytes
             let bytes = concat_u8_arrays(vec![
@@ -80,11 +86,13 @@ impl EthereumEventHandler {
                 &request_nonce.as_u128().to_le_bytes(),
             ]);
 
-            trace!("event concatenated bytes: {bytes:?}");
+            trace!("Concatenated event bytes: {bytes:?}");
 
             let request_hash = keccak256(bytes);
+            debug!("Hashed event data: {request_hash:?}");
+
             let request_hash_hex = hex::encode(request_hash);
-            info!("hashed event encoding: 0x{}", request_hash_hex);
+            info!("Request hash hex encoding: 0x{}", request_hash_hex);
 
             if let Some(blacklist) = blacklisted_requests {
                 if blacklist.contains(&H256::from_str(&request_hash_hex)?) {
@@ -107,7 +115,7 @@ impl EthereumEventHandler {
             let request_nonce = request_nonce.as_u128();
 
             if not_in_committee(&contract, azero_connection, committee_id).await? {
-                info!("Guardian signature for {request_hash:?} not needed - request from a different committee");
+                info!("Guardian signature for 0x{request_hash_hex} not needed - request from a different committee");
                 return Ok(());
             }
 
@@ -132,7 +140,7 @@ impl EthereumEventHandler {
                     request_nonce,
                 })?;
 
-            info!("Guardian signature for {request_hash:?} no longer needed");
+            info!("Guardian signature for 0x{request_hash_hex} no longer needed");
         }
 
         Ok(())

--- a/relayer/relayer/src/handlers/eth.rs
+++ b/relayer/relayer/src/handlers/eth.rs
@@ -213,8 +213,11 @@ impl EthereumEventsHandler {
                     let EthMostEvents {
                         events,
                         events_ack_sender,
+                        from_block,
+                        to_block
                     } = eth_events;
-                    info!("Received a batch of {} events", events.len());
+
+                    info!("Received a batch of {} events from blocks {from_block} to {to_block}", events.len());
 
                     for event in events {
                         select! {
@@ -241,7 +244,6 @@ impl EthereumEventsHandler {
                         .map_err(|_| EthereumEventsHandlerError::EventsAckReceiverDropped)?;
 
                 }
-
             }
         }
     }

--- a/relayer/relayer/src/listeners/azero.rs
+++ b/relayer/relayer/src/listeners/azero.rs
@@ -127,7 +127,7 @@ impl AlephZeroListener {
 
                     let to_block = min(
                         next_finalized_block_number,
-                        unprocessed_block_number + (*sync_step) - 1,
+                        unprocessed_block_number + sync_step - 1,
                     );
 
                     info!(target: "AlephZeroListener",

--- a/relayer/relayer/src/listeners/eth.rs
+++ b/relayer/relayer/src/listeners/eth.rs
@@ -122,6 +122,8 @@ impl EthereumListener {
                                         eth_events_sender
                                             .send(EthMostEvents {
                                                 events: events.clone (),
+                                                from_block: unprocessed_block_number,
+                                                to_block,
                                                 events_ack_sender,
                                             }).await?;
 

--- a/relayer/relayer/src/listeners/mod.rs
+++ b/relayer/relayer/src/listeners/mod.rs
@@ -9,6 +9,8 @@ mod eth;
 
 #[derive(Debug)]
 pub struct EthMostEvents {
+    pub from_block: u32,
+    pub to_block: u32,
     pub events: Vec<MostEvents>,
     pub events_ack_sender: oneshot::Sender<()>,
 }


### PR DESCRIPTION
- one handler logged request_hashes
- ...the second handler logged the nonces instead
- both logged bare bytes, which is great, but if I want to check it later in the contract, I had to encode it in hex myself

so i fixed that

Moved some methods around so that mutations are grouped with mutations, getters with getters