### PR TITLE
Reduce number of rpc request to ethereum endpoint + increase number of confirmations

### DIFF
--- a/.github/workflows/on-master-branch-commit.yml
+++ b/.github/workflows/on-master-branch-commit.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - kz/eth-request-frequency
 
 jobs:
   check-vars-and-secrets:

--- a/.github/workflows/on-master-branch-commit.yml
+++ b/.github/workflows/on-master-branch-commit.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - kz/eth-request-frequency
 
 jobs:
   check-vars-and-secrets:

--- a/relayer/relayer/src/config.rs
+++ b/relayer/relayer/src/config.rs
@@ -94,7 +94,7 @@ pub struct Config {
     #[arg(long, default_value = "200000")]
     pub eth_gas_limit: u32,
 
-    #[arg(long, default_value = "30")]
+    #[arg(long, default_value = "90")]
     pub eth_poll_interval: u64,
 
     #[arg(long, default_value = "100")]

--- a/relayer/relayer/src/config.rs
+++ b/relayer/relayer/src/config.rs
@@ -85,7 +85,7 @@ pub struct Config {
     #[arg(long, default_value = "10")]
     pub eth_tx_submission_retries: usize,
 
-    #[arg(long, default_value = "8")]
+    #[arg(long, default_value = "32")]
     pub eth_tx_min_confirmations: usize,
 
     #[arg(long, default_value = "1")]

--- a/relayer/relayer/src/config.rs
+++ b/relayer/relayer/src/config.rs
@@ -94,6 +94,9 @@ pub struct Config {
     #[arg(long, default_value = "200000")]
     pub eth_gas_limit: u32,
 
+    #[arg(long, default_value = "30")]
+    pub eth_poll_interval: u64,
+
     #[arg(long, default_value = "100")]
     pub sync_step: u32,
 

--- a/relayer/relayer/src/connections/eth.rs
+++ b/relayer/relayer/src/connections/eth.rs
@@ -207,7 +207,9 @@ impl Signer for EthVsockSigner {
 }
 
 pub async fn connect(config: &Config) -> EthConnection {
-    Provider::<Http>::connect(&config.eth_node_http_url).await.interval(Duration::from_secs(config.eth_poll_interval))
+    Provider::<Http>::connect(&config.eth_node_http_url)
+        .await
+        .interval(Duration::from_secs(config.eth_poll_interval))
 }
 
 pub async fn with_local_wallet(

--- a/relayer/relayer/src/connections/eth.rs
+++ b/relayer/relayer/src/connections/eth.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, time::Duration};
 
 use ethers::{
     abi::Address,
@@ -18,6 +18,8 @@ use ethers::{
 };
 use thiserror::Error;
 use tokio::sync::Mutex;
+
+use crate::config::Config;
 
 pub type EthConnection = Provider<Http>;
 pub type SignedEthConnection =
@@ -204,8 +206,8 @@ impl Signer for EthVsockSigner {
     }
 }
 
-pub async fn connect(url: &str) -> EthConnection {
-    Provider::<Http>::connect(url).await
+pub async fn connect(config: &Config) -> EthConnection {
+    Provider::<Http>::connect(&config.eth_node_http_url).await.interval(Duration::from_secs(config.eth_poll_interval))
 }
 
 pub async fn with_local_wallet(

--- a/relayer/relayer/src/contracts/azero.rs
+++ b/relayer/relayer/src/contracts/azero.rs
@@ -17,7 +17,7 @@ use aleph_client::{
     sp_weights::weight_v2::Weight,
     AccountId, AlephConfig, Connection, SignedConnectionApi, TxInfo, TxStatus,
 };
-use log::{error, trace};
+use log::{error, trace, info};
 use subxt::events::Events;
 use thiserror::Error;
 
@@ -140,6 +140,7 @@ impl MostInstance {
         let dry_run_res = match signed_connection.call_and_get(dry_run_args).await?.result {
             Ok(res) => res,
             Err(why) => {
+                error!("Dry run failed: {:?}", why);    
                 return Err(AzeroContractError::DispatchError(format!("{:?}", why)));
             }
         };
@@ -153,7 +154,7 @@ impl MostInstance {
             return Err(AzeroContractError::DryRunReverted(decoded_value));
         }
 
-        signed_connection
+        let call_result = signed_connection
             .call(
                 self.address.clone(),
                 0,
@@ -163,7 +164,9 @@ impl MostInstance {
                 TxStatus::Finalized,
             )
             .await
-            .map_err(AzeroContractError::AlephClient)
+            .map_err(AzeroContractError::AlephClient);
+        info!("receive_request: {:?}", call_result);
+        call_result
     }
 
     pub async fn is_halted(&self, connection: &Connection) -> Result<bool, AzeroContractError> {

--- a/relayer/relayer/src/contracts/azero.rs
+++ b/relayer/relayer/src/contracts/azero.rs
@@ -17,7 +17,7 @@ use aleph_client::{
     sp_weights::weight_v2::Weight,
     AccountId, AlephConfig, Connection, SignedConnectionApi, TxInfo, TxStatus,
 };
-use log::{error, trace, info};
+use log::{error, info, trace};
 use subxt::events::Events;
 use thiserror::Error;
 
@@ -140,7 +140,7 @@ impl MostInstance {
         let dry_run_res = match signed_connection.call_and_get(dry_run_args).await?.result {
             Ok(res) => res,
             Err(why) => {
-                error!("Dry run failed: {:?}", why);    
+                error!("Dry run failed: {:?}", why);
                 return Err(AzeroContractError::DispatchError(format!("{:?}", why)));
             }
         };

--- a/relayer/relayer/src/main.rs
+++ b/relayer/relayer/src/main.rs
@@ -139,12 +139,7 @@ async fn create_eth_connections(
 ) -> Result<(Arc<EthConnection>, Arc<SignedEthConnection>), EthConnectionError> {
     let eth_signed_connection = if let Some(cid) = config.signer_cid {
         info!("Creating signed connection using a Signer client");
-        eth::with_signer(
-            eth::connect(config).await,
-            cid,
-            config.signer_port,
-        )
-        .await?
+        eth::with_signer(eth::connect(config).await, cid, config.signer_port).await?
     } else if config.dev {
         let wallet =
             // use the default development mnemonic

--- a/relayer/relayer/src/main.rs
+++ b/relayer/relayer/src/main.rs
@@ -140,7 +140,7 @@ async fn create_eth_connections(
     let eth_signed_connection = if let Some(cid) = config.signer_cid {
         info!("Creating signed connection using a Signer client");
         eth::with_signer(
-            eth::connect(&config.eth_node_http_url).await,
+            eth::connect(config).await,
             cid,
             config.signer_port,
         )
@@ -157,13 +157,13 @@ async fn create_eth_connections(
             "Creating signed connection using a development key {}",
             &wallet.address()
         );
-        eth::with_local_wallet(eth::connect(&config.eth_node_http_url).await, wallet).await?
+        eth::with_local_wallet(eth::connect(config).await, wallet).await?
     } else {
         panic!("Use dev mode or connect to a signer");
     };
 
     Ok((
-        Arc::new(eth::connect(&config.eth_node_http_url).await),
+        Arc::new(eth::connect(config).await),
         Arc::new(eth_signed_connection),
     ))
 }

--- a/relayer/scripts/entrypoint.sh
+++ b/relayer/scripts/entrypoint.sh
@@ -125,5 +125,9 @@ if [[ -n "${ETH_POLL_INTERVAL}" ]]; then
   ARGS+=(--eth-poll-interval=${ETH_POLL_INTERVAL})
 fi
 
+if [[ -n "${ETH_MIN_CONFIRMATIONS}" ]]; then
+  ARGS+=(--eth-tx-min-confirmations=${ETH_MIN_CONFIRMATIONS})
+fi
+
 # --- RUN
 xargs most-relayer "${ARGS[@]}"

--- a/relayer/scripts/entrypoint.sh
+++ b/relayer/scripts/entrypoint.sh
@@ -117,5 +117,13 @@ if [[ -n "${SIGNER_CID}" ]]; then
   ARGS+=(--signer-cid=${SIGNER_CID})
 fi
 
+if [[ -n "${SYNC_STEP}" ]]; then
+  ARGS+=(--sync-step=${SYNC_STEP})
+fi
+
+if [[ -n "${ETH_POLL_INTERVAL}" ]]; then
+  ARGS+=(--eth-poll-interval=${ETH_POLL_INTERVAL})
+fi
+
 # --- RUN
 xargs most-relayer "${ARGS[@]}"


### PR DESCRIPTION
Reducing the frequency with which the eth provider polls should significantly reduce the number of requests generated by the relayer.

More importantly there was a bug that caused "leakage" of tokio tasks during a circuit-breaker restarts that caused number of requests to go up significantly.