### PR TITLE
A0-2999: Bump all workflows to use node20

### DIFF
--- a/.github/workflows/_relayer-build-and-push.yml
+++ b/.github/workflows/_relayer-build-and-push.yml
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - name: Checkout Source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Call action get-ref-properties
         id: get-ref-properties

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Install Rust toolchain"
-        uses: Cardinal-Cryptography/aleph-node/.github/actions/install-rust-toolchain@5eda3cd85e7e3aec3f2db7a26631c65d52c4b9ea
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v6
 
       - name: Check code formatting
         shell: bash

--- a/.github/workflows/contracts-compile-and-deploy-to-bridgenet.yml
+++ b/.github/workflows/contracts-compile-and-deploy-to-bridgenet.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: asdf-vm/actions/install@v2
+        uses: asdf-vm/actions/install@v3
 
       - name: Deploy eth contracts
         shell: bash
@@ -109,7 +109,7 @@ jobs:
       matrix: ${{ fromJson(needs.deploy-contracts.outputs.artifact-matrix-json) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4
         with:
@@ -140,7 +140,7 @@ jobs:
     needs: [deploy-contracts]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/devnet-eth-nodes-recreate.yml
+++ b/.github/workflows/devnet-eth-nodes-recreate.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, small]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup kubectl
         uses: azure/setup-kubectl@v3.2
@@ -27,7 +27,7 @@ jobs:
           version: 'v1.23.6'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         env:
           AWS_REGION: eu-central-1
         with:

--- a/.github/workflows/lint-contracts.yml
+++ b/.github/workflows/lint-contracts.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Install Rust toolchain"
-        uses: Cardinal-Cryptography/aleph-node/.github/actions/install-rust-toolchain@5eda3cd85e7e3aec3f2db7a26631c65d52c4b9ea
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v6
 
       - name: Lint contracts code
         shell: bash

--- a/.github/workflows/lint-relayer.yml
+++ b/.github/workflows/lint-relayer.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Install Rust toolchain"
-        uses: Cardinal-Cryptography/aleph-node/.github/actions/install-rust-toolchain@5eda3cd85e7e3aec3f2db7a26631c65d52c4b9ea
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v6
 
       - name: Lint relayer code
         shell: bash

--- a/.github/workflows/signer-build-and-push.yml
+++ b/.github/workflows/signer-build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
       RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout Source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Call action get-ref-properties
         id: get-ref-properties

--- a/.github/workflows/test-azero-contracts.yml
+++ b/.github/workflows/test-azero-contracts.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Install Rust toolchain"
-        uses: Cardinal-Cryptography/aleph-node/.github/actions/install-rust-toolchain@5eda3cd85e7e3aec3f2db7a26631c65d52c4b9ea
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v6
 
       - name: "Install Docker Compose"
         uses: KengoTODA/actions-setup-docker-compose@v1

--- a/.github/workflows/test-eth-contracts.yml
+++ b/.github/workflows/test-eth-contracts.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run tests
         shell: bash

--- a/.github/workflows/test-relayer.yml
+++ b/.github/workflows/test-relayer.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Install Rust toolchain"
-        uses: Cardinal-Cryptography/aleph-node/.github/actions/install-rust-toolchain@5eda3cd85e7e3aec3f2db7a26631c65d52c4b9ea
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v6
 
       - name: Run tests
         shell: bash


### PR DESCRIPTION
See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ for more info.