### PR TITLE
Improve advisory handling

### DIFF
--- a/relayer/relayer/src/config.rs
+++ b/relayer/relayer/src/config.rs
@@ -56,19 +56,19 @@ pub struct Config {
     /// Trader component will always keep this + current base_fee in the guardians balance and will only sell the surplus
     ///
     /// Defaults to 1000 AZERO
-    #[arg(long, default_value = "1_000_000_000_000_000")]
+    #[arg(long, default_value = "1000000000000000")]
     pub eth_to_azero_relaying_buffer: u128,
 
     /// Trader component will bridge azero wETH after the balance exceeds this amount
     ///
     /// Defaults to 0.1 ETH
-    #[arg(long, default_value = "100_000_000_000_000_000")]
+    #[arg(long, default_value = "100000000000000000")]
     pub bridging_threshold: u128,
 
     /// Trader component will claim rewards when they exceed this value
     ///
     /// Defaults to 10 AZERO
-    #[arg(long, default_value = "10_000_000_000_000")]
+    #[arg(long, default_value = "10000000000000")]
     pub reward_withdrawal_threshold: u128,
 
     #[arg(long)]

--- a/relayer/relayer/src/listeners/azero.rs
+++ b/relayer/relayer/src/listeners/azero.rs
@@ -150,18 +150,18 @@ impl AlephZeroListener {
                         })
                         .collect::<Vec<ContractEvent>>();
 
-                    let (ack_sender, ack_receiver) = oneshot::channel::<u32> ();
+                    let (ack_sender, ack_receiver) = oneshot::channel::<u32>();
                     event_batch_ack_receiver.push_back(ack_receiver);
 
                     select! {
-                        cb_event = circuit_breaker_receiver.recv () => {
+                        cb_event = circuit_breaker_receiver.recv() => {
                             warn!(target: "AlephZeroListener", "Exiting before sending events due to a circuit breaker event {cb_event:?}");
                             return Ok(cb_event?);
                         },
 
-                        Ok (_) = azero_events_sender
+                        Ok(_) = azero_events_sender
                             .send(AzeroMostEvents {
-                                events: filtered_events.clone (),
+                                events: filtered_events.clone(),
                                 from_block: unprocessed_block_number,
                                 to_block,
                                 ack: ack_sender


### PR DESCRIPTION
PR aims to address two issues:
- Receivers of circuit breaker messages were created after starting the components: this can lead to a signal being sent only to some of the components, so the relayer ends up in a state where some of the components are working fine, but the other are inactive. In particular, it could happen that advisory listener would abort (due to advisory activation) before any of the other components started running - in such a case the advisory activation would be mostly ignored.
- Since there was no check that advisories are inactive before the components are started, it was possible that event handlers would be scheduled favorably and manage to submit a tx before advisory listener observed the activation and sent cb signal. 