### PR TITLE
Most-90: Evm finalization changes

### DIFF
--- a/relayer/relayer/src/contracts/eth.rs
+++ b/relayer/relayer/src/contracts/eth.rs
@@ -1,4 +1,59 @@
-use ethers::contract::abigen;
+use aleph_client::sp_core::H160;
+use ethers::{
+    contract::{abigen, ContractError},
+    middleware::Middleware,
+    prelude::BlockNumber,
+};
 
 abigen!(Most, "../eth/artifacts/contracts/Most.sol/Most.json");
 abigen!(WETH9, "../eth/artifacts/contracts/WETH9.sol/WETH9.json");
+
+pub enum SignatureState {
+    #[cfg_attr(feature = "evm", allow(dead_code))]
+    SignedNotFinalized,
+    NeedSignature,
+    Finalized,
+}
+
+#[cfg(feature = "evm")]
+pub async fn contract_signature_state<C: Middleware + 'static>(
+    contract: &Most<C>,
+    request_hash: [u8; 32],
+    address: H160,
+    committee_id: u128,
+) -> Result<SignatureState, ContractError<C>> {
+    use SignatureState::*;
+    if !contract
+        .needs_signature(request_hash, address, committee_id.into())
+        .block(BlockNumber::Latest)
+        .await?
+    {
+        Ok(Finalized)
+    } else {
+        Ok(NeedSignature)
+    }
+}
+
+#[cfg(not(feature = "evm"))]
+pub async fn contract_signature_state<C: Middleware + 'static>(
+    contract: &Most<C>,
+    request_hash: [u8; 32],
+    address: H160,
+    committee_id: u128,
+) -> Result<SignatureState, ContractError<C>> {
+    use SignatureState::*;
+    let is_finalized = !contract
+        .needs_signature(request_hash, address, committee_id.into())
+        .block(BlockNumber::Finalized)
+        .await?;
+    let is_signed = !contract
+        .needs_signature(request_hash, address, committee_id.into())
+        .block(BlockNumber::Latest)
+        .await?;
+
+    Ok(match (is_signed, is_finalized) {
+        (_, true) => Finalized,          // Does not need signature on finalized block
+        (true, _) => SignedNotFinalized, // Signed but not yet finalized
+        (false, _) => NeedSignature,     // Not signed and not finalized
+    })
+}

--- a/relayer/relayer/src/handlers/azero.rs
+++ b/relayer/relayer/src/handlers/azero.rs
@@ -74,12 +74,12 @@ impl AlephZeroEventHandler {
             ..
         } = &*config;
 
-        match &event.name {
-            Some(name) if name.eq("CrosschainTransferRequest") => {}
-            _ => {
-                debug!("Skipping non azero contract event");
-                return Ok(());
-            }
+        if !event
+            .name
+            .is_some_and(|name| name.eq("CrosschainTransferRequest"))
+        {
+            debug!("Skipping non azero contract event");
+            return Ok(());
         }
 
         let data = event.data;
@@ -149,11 +149,11 @@ impl AlephZeroEventHandler {
             )
             .await?
             {
-                SignatureState::Finalized => {
+                SignatureState::Signed { finalized: true } => {
                     info!("Guardian signature for 0x{request_hash_hex} no longer needed");
                     return Ok(());
                 }
-                SignatureState::SignedNotFinalized => {
+                SignatureState::Signed { finalized: false } => {
                     info!("Request 0x{request_hash_hex} not yet finalized.");
                     sleep(Duration::from_secs(ETH_WAIT_FOR_FINALITY_CHECK_SEC)).await;
                 }

--- a/relayer/relayer/src/handlers/azero.rs
+++ b/relayer/relayer/src/handlers/azero.rs
@@ -85,15 +85,17 @@ impl AlephZeroEventHandler {
         let data = event.data;
 
         // decode event data
-        let crosschain_transfer_event @ CrosschainTransferRequestData {
+        let crosschain_transfer_event = get_request_event_data(&data)?;
+
+        debug!("Handling azero contract event: {crosschain_transfer_event:?}");
+
+        let CrosschainTransferRequestData {
             committee_id,
             dest_token_address,
             amount,
             dest_receiver_address,
             request_nonce,
-        } = get_request_event_data(&data)?;
-
-        debug!("Handling azero contract event: {crosschain_transfer_event:?}");
+        } = crosschain_transfer_event;
 
         // NOTE: for some reason, ethers-rs's `encode_packed` does not properly encode the data
         // (it does not pad uint to 32 bytes, but uses the actual number of bytes required to store the value)


### PR DESCRIPTION
This pr containst two important changes and few stylistic ones:
* evm finalization notion in listener - commit [b7bde16](https://github.com/Cardinal-Cryptography/most/pull/201/commits/b7bde16361ef7973fdd488acdbe777c5b2db85f6)
* evm finalizaiton notion in handler - commit [e940ee5](https://github.com/Cardinal-Cryptography/most/pull/201/commits/e940ee5e09f4a2db1c95665412ace23aa298a95a)

Commit [8bbed39](https://github.com/Cardinal-Cryptography/most/pull/201/commits/8bbed39fafed9c8bd36b6fcd67f8b05cc75da546) and larger part of commit [e940ee5](https://github.com/Cardinal-Cryptography/most/pull/201/commits/e940ee5e09f4a2db1c95665412ace23aa298a95a) contains reorganization of the code to avoid deep nested code blocks.