### PR TITLE
MOST-74: Store yet-empty JSON with L2 addresses in S3 bucket

### DIFF
--- a/.github/workflows/contracts-compile-and-deploy-to-devenv.yml
+++ b/.github/workflows/contracts-compile-and-deploy-to-devenv.yml
@@ -237,3 +237,23 @@ jobs:
           frontend-environment: most0
           src-addresses: contract_spec_with_block_numbers.json
           if-exist: overwrite
+
+      - name: Mock contract spec JSON for L2
+        shell: bash
+        run: |
+          cp contract_spec_with_block_numbers.json l2_contract_spec.json
+          cat l2_contract_spec.json | jq '.addresses = {}' | jq ".start_blocks = { evm: \"$ETH_START_BLOCK\", l2_azero: \"$AZERO_START_BLOCK\" }" \
+            > l2_contract_spec_with_block_numbers.json
+
+      - name: Store L2 addresses in S3 bucket
+        uses: Cardinal-Cryptography/github-actions/store-contract-addresses@v6
+        with:
+          aws-access-key-id: ${{ secrets.CONTRACTS_MOST_ADDRESSES_TESTNET_MOST0_RW_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CONTRACTS_MOST_ADDRESSES_TESTNET_MOST0_RW_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.CONTRACTS_S3BUCKET_REGION }}
+          s3-bucket: ${{ secrets.CONTRACTS_S3BUCKET_NAME }}
+          project: most
+          chain-environment: testnet
+          frontend-environment: l2_most0
+          src-addresses: l2_contract_spec_with_block_numbers.json
+          if-exist: overwrite


### PR DESCRIPTION
Adds a step that would upload a dummy JSON for L2 contract addresses, and start blocks (these guys weren't in the "contract spec JSON" file previously). With these, we can already prepare Guardian package to download the l2_most0.json file.