### PR TITLE
MOSt-175: Simplify MOST L1 dev deployment

### DIFF
--- a/azero/env/testnet.json
+++ b/azero/env/testnet.json
@@ -1,0 +1,22 @@
+{
+  "ws_node": "wss://ws.test.azero.dev",
+  "relayers": [
+    "<deployer account id>"
+  ],
+  "deployer_seed": "<deployer seed>",
+  "signature_threshold": 1,
+  "pocket_money": 1000000000000,
+  "min_gas_price": 60000000,
+  "max_gas_price": 450000000,
+  "default_gas_price": 180000000,
+  "relay_gas_usage": 450000,
+  "dev": true,
+  "tokens": [
+    {
+      "symbol": "wETH",
+      "name": "Wrapped Ether",
+      "decimals": 18,
+      "checkAddress": "weth"
+    }
+  ]
+}

--- a/azero/env/testnet.json
+++ b/azero/env/testnet.json
@@ -10,7 +10,7 @@
   "max_gas_price": 450000000,
   "default_gas_price": 180000000,
   "relay_gas_usage": 450000,
-  "dev": true,
+  "dev": false,
   "tokens": [
     {
       "symbol": "wETH",

--- a/azero/package.json
+++ b/azero/package.json
@@ -6,7 +6,7 @@
     "description": "azero most bridge",
     "scripts": {
         "watch": "gulp default",
-        "compile": "typechain-compiler --release --toolchain nightly-2024-02-16",
+        "compile": "typechain-compiler --release --toolchain nightly-2024-04-28",
         "predrink-tests": "npm config set script-shell \"/bin/bash\"; ./scripts/predrink_tests.sh",
         "drink-tests": "npm config set script-shell \"/bin/bash\"; ./scripts/drink_tests.sh",
         "deploy": "npm config set script-shell \"/bin/bash\"; ts-node scripts/0_upload_code.ts; ts-node scripts/1_deploy.ts",

--- a/azero/scripts/1_deploy.ts
+++ b/azero/scripts/1_deploy.ts
@@ -1,6 +1,5 @@
 import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
-import Migrations from "../types/contracts/migrations";
 import MigrationsConstructors from "../types/constructors/migrations";
 import MostConstructors from "../types/constructors/most";
 import TokenConstructors from "../types/constructors/token";
@@ -174,9 +173,6 @@ async function main(): Promise<void> {
 
     tokenAddresses.push([token.symbol, ethAddress, address]);
   }
-
-  const migrations = new Migrations(migrationsAddress, deployer, api);
-  await migrations.tx.setCompleted(1);
 
   const addresses: Addresses = {
     migrations: migrationsAddress,

--- a/azero/scripts/2_setup.ts
+++ b/azero/scripts/2_setup.ts
@@ -1,11 +1,9 @@
 import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
-import Migrations from "../types/contracts/migrations";
 import Most from "../types/contracts/most";
 import Token from "../types/contracts/token";
 import {
   import_env,
   import_azero_addresses,
-  import_eth_addresses,
   accountIdToHex,
   hexToBytes,
 } from "./utils";
@@ -56,7 +54,6 @@ async function main(): Promise<void> {
   const {
     tokens,
     most: most_azero,
-    migrations: migrations_azero,
   } = await import_azero_addresses();
 
   const wsProvider = new WsProvider(ws_node);
@@ -66,17 +63,6 @@ async function main(): Promise<void> {
   const deployer = keyring.addFromUri(deployer_seed);
 
   console.log("Using ", deployer.address, "as the transaction signer");
-
-  const migrations = new Migrations(migrations_azero, deployer, api);
-
-  // check migrations
-  let lastCompletedMigration = await migrations.query.lastCompletedMigration();
-  const number = lastCompletedMigration.value.ok;
-  console.log("Last completed migration: ", number);
-  if (number != 1) {
-    console.error("Previous migration has not been completed");
-    process.exit(-1);
-  }
 
   // premint some token for DEV
   if (dev) {
@@ -100,12 +86,6 @@ async function main(): Promise<void> {
       await most.tx.setWeth(azero_address);
     }
   }
-
-  if (dev) {
-    await most.tx.setHalted(false);
-  }
-
-  await migrations.tx.setCompleted(2);
 
   await api.disconnect();
   console.log("Done");

--- a/eth/hardhat.config.js
+++ b/eth/hardhat.config.js
@@ -47,31 +47,6 @@ var config = {
         governanceThreshold: 2,
       },
     },
-
-    bridgenet: {
-      url: "https://rpc-eth-bridgenet.dev.azero.dev",
-      accounts: {
-        mnemonic: DEV_MNEMONIC,
-      },
-      governanceThreshold: 2,
-      chainId: 12_345,
-      gas: 25e6, // Gas limit
-      gasPrice: 20e9,
-      deploymentConfig: {
-        guardianIds: [
-          "0x05501355922a6529670DB49158676D98D6c34245",
-          "0x084321C892ebb289dA2131d18a39fdfC3CCC0D2C",
-          "0xd7a898720ab24ae154d67f51F2F75341D2A3719f",
-        ],
-        threshold: 2,
-        governanceIds: [
-          "0x05501355922a6529670DB49158676D98D6c34245",
-          "0x084321C892ebb289dA2131d18a39fdfC3CCC0D2C",
-          "0xd7a898720ab24ae154d67f51F2F75341D2A3719f",
-        ],
-        governanceThreshold: 2,
-      },
-    },
   },
   solidity: {
     compilers: [
@@ -112,11 +87,14 @@ if (SEPOLIA_KEY) {
     accounts: [SEPOLIA_KEY],
     deploymentConfig: {
       guardianIds: [
-        "0xc4E0B92Df2DE77C077D060e49ec63DC196980716", // sepolia account address corresponding to SEPOLIA_KEY
+        "0xc4E0B92Df2DE77C077D060e49ec63DC196980716",
       ],
       threshold: 1,
-      weth: "0xd91aE8FD2Be53F74876a9cc4aFb416645A0c8420",
     },
+    weth: "0xd91aE8FD2Be53F74876a9cc4aFb416645A0c8420",
+    dev: false,
+    gas: 25e6,
+    gasPrice: 20e9,
   };
 }
 

--- a/eth/scripts/2_deploy_bridge_contracts.js
+++ b/eth/scripts/2_deploy_bridge_contracts.js
@@ -10,12 +10,12 @@ async function main() {
 
 
   let addresses = {};
-  if (fs.existsSync("addresses.json") {
+  if (fs.existsSync("addresses.json")) {
     addresses = JSON.parse(
         fs.readFileSync("addresses.json", { encoding: "utf8", flag: "r" }),
     );
   }
-  
+
   if (config.dev) {
     const WETH = await ethers.getContractFactory("WETH9");
     console.log("Deploying WETH...");

--- a/eth/scripts/2_deploy_bridge_contracts.js
+++ b/eth/scripts/2_deploy_bridge_contracts.js
@@ -8,11 +8,14 @@ async function main() {
 
   console.log("Using ", accounts[0], "as the transaction signer");
 
-  // read addresses
-  let addresses = JSON.parse(
-    fs.readFileSync("addresses.json", { encoding: "utf8", flag: "r" }),
-  );
 
+  let addresses = {};
+  if (fs.existsSync("addresses.json") {
+    addresses = JSON.parse(
+        fs.readFileSync("addresses.json", { encoding: "utf8", flag: "r" }),
+    );
+  }
+  
   if (config.dev) {
     const WETH = await ethers.getContractFactory("WETH9");
     console.log("Deploying WETH...");

--- a/eth/scripts/3_setup_bridge_contracts.js
+++ b/eth/scripts/3_setup_bridge_contracts.js
@@ -23,7 +23,7 @@ async function addTokenPair(
   const azeroTokenAddressBytes = u8aToHex(
     new Keyring({ type: "sr25519" }).decodeAddress(azeroTokenAddress),
   );
-  mostContract.addPair(
+  await mostContract.addPair(
       ethTokenAddressBytes,
       azeroTokenAddressBytes,
   );

--- a/eth/scripts/3_setup_bridge_contracts.js
+++ b/eth/scripts/3_setup_bridge_contracts.js
@@ -2,42 +2,13 @@ const fs = require("node:fs");
 const { ethers, artifacts, network } = require("hardhat");
 const { Keyring } = require("@polkadot/keyring");
 const { u8aToHex } = require("@polkadot/util");
-const Safe = require("@safe-global/protocol-kit").default;
-const { EthersAdapter } = require("@safe-global/protocol-kit");
 
 const azeroContracts = require("../../azero/addresses.json");
-
-async function createSafeInstance(signer, contracts) {
-  const ethAdapter = new EthersAdapter({
-    ethers,
-    signerOrProvider: signer,
-  });
-  const chainId = await ethAdapter.getChainId();
-  const contractNetworks = {
-    [chainId]: {
-      safeSingletonAddress: contracts.gnosis.safeSingletonAddress,
-      safeProxyFactoryAddress: contracts.gnosis.safeProxyFactoryAddress,
-      multiSendAddress: contracts.gnosis.multiSendAddress,
-      multiSendCallOnlyAddress: contracts.gnosis.multiSendCallOnlyAddress,
-      fallbackHandlerAddress: contracts.gnosis.fallbackHandlerAddress,
-      signMessageLibAddress: contracts.gnosis.signMessageLibAddress,
-      createCallAddress: contracts.gnosis.createCallAddress,
-      simulateTxAccessorAddress: contracts.gnosis.simulateTxAccessorAddress,
-    },
-  };
-
-  return await Safe.create({
-    ethAdapter: ethAdapter,
-    safeAddress: contracts.gnosis.safe,
-    contractNetworks,
-  });
-}
 
 async function addTokenPair(
   ethTokenAddress,
   azeroTokenAddress,
   mostContract,
-  safeInstances,
 ) {
   console.log(
     "Adding token pair to Most:",
@@ -52,94 +23,22 @@ async function addTokenPair(
   const azeroTokenAddressBytes = u8aToHex(
     new Keyring({ type: "sr25519" }).decodeAddress(azeroTokenAddress),
   );
-
-  const iface = await new ethers.Interface([
-    "function addPair(bytes32 from, bytes32 to)",
-  ]);
-
-  const addPaircalldata = await iface.encodeFunctionData("addPair", [
-    ethTokenAddressBytes,
-    azeroTokenAddressBytes,
-  ]);
-
-  const transactions = [
-    {
-      to: mostContract.address,
-      data: addPaircalldata,
-      value: 0,
-    },
-  ];
-
-  console.log("creating a Safe transactions:", transactions);
-
-  const safeTransaction = await safeInstances[0].createTransaction({
-    transactions,
-  });
-  const safeTxHash = await safeInstances[0].getTransactionHash(safeTransaction);
-
-  console.log("safeTxHash", safeTxHash);
-
-  for (const safeInstance of safeInstances) {
-    await signSafeTransaction(safeInstance, safeTxHash);
-  }
-
-  // execute safe tx
-  await executeSafeTransaction(safeInstances[0], safeTransaction);
+  mostContract.addPair(
+      ethTokenAddressBytes,
+      azeroTokenAddressBytes,
+  );
 
   console.log(
-    "Most now supports the token pair:",
-    ethTokenAddressBytes,
-    "=>",
-    await mostContract.supportedPairs(ethTokenAddressBytes),
+      "Most now supports the token pair:",
+      ethTokenAddressBytes,
+      "=>",
+      await mostContract.supportedPairs(ethTokenAddressBytes),
   );
-}
-
-async function unpauseMost(mostContract, safeInstances) {
-  console.log("Unpausing Most:");
-
-  const iface = await new ethers.Interface(["function unpause()"]);
-
-  const transactions = [
-    {
-      to: mostContract.address,
-      data: await iface.encodeFunctionData("unpause", []),
-      value: 0,
-    },
-  ];
-
-  console.log("creating a Safe transactions:", transactions);
-
-  const safeTransaction = await safeInstances[0].createTransaction({
-    transactions,
-  });
-  const safeTxHash = await safeInstances[0].getTransactionHash(safeTransaction);
-
-  console.log("safeTxHash", safeTxHash);
-
-  for (const safeInstance of safeInstances) {
-    await signSafeTransaction(safeInstance, safeTxHash);
-  }
-
-  // execute safe tx
-  await executeSafeTransaction(safeInstances[0], safeTransaction);
-
-  console.log("Most is now unpaused.");
-}
-
-// signing with on-chain signatures
-async function signSafeTransaction(safeInstance, txHash) {
-  const approveTxResponse = await safeInstance.approveTransactionHash(txHash);
-  await approveTxResponse.transactionResponse?.wait();
-}
-
-async function executeSafeTransaction(safeInstance, safeTransaction) {
-  const executeTxResponse =
-    await safeInstance.executeTransaction(safeTransaction);
-  await executeTxResponse.transactionResponse?.wait();
 }
 
 async function main() {
   const signers = await ethers.getSigners();
+  const config = network.config;
   accounts = signers.map((s) => s.address);
 
   console.log("Using ", accounts[0], "as signer");
@@ -149,64 +48,21 @@ async function main() {
     fs.readFileSync("addresses.json", { encoding: "utf8", flag: "r" }),
   );
 
-  const Migrations = artifacts.require("Migrations");
-  const migrations = await Migrations.at(addresses.migrations);
-
-  // check migratons
-  let lastCompletedMigration = await migrations.last_completed_migration();
-  lastCompletedMigration = lastCompletedMigration.toNumber();
-  console.log("Last completed migration: ", lastCompletedMigration);
-  if (lastCompletedMigration != 2) {
-    console.error("Previous migration has not been completed");
-    process.exit(-1);
-  }
-
-  // --- setup
-
   const Most = artifacts.require("Most");
   const most = await Most.at(addresses.most);
 
-  if (network.name == "development" || network.name == "bridgenet") {
-    // NOTE : TEMPorary before devnet is fixed and uses proper genesis that seeds these accounts with funds
-    for (const to of signers.slice(1, 4)) {
-      await signers[0].sendTransaction({
-        to: to.address,
-        value: ethers.parseEther("1.0"), // Send 1.0 ether
-      });
-    }
-
-    // --- provide some wETH and USDT to most contract
+  if (config.dev) {
+    // Provide some wETH to most contract
     const WETH = artifacts.require("WETH9");
     const weth = await WETH.at(addresses.weth);
 
     await weth.deposit({ value: 1000000000000000 });
     await weth.transfer(addresses.most, 1000000000000000);
-
-    const Token = artifacts.require("Token");
-    const usdt = await Token.at(addresses.usdt);
-    await usdt.transfer(addresses.most, 1000000000000000);
-
-    // --- add  pairs
-    const signer0 = signers[1];
-    const signer1 = signers[2];
-    const safeSdk0 = await createSafeInstance(signer0, addresses);
-    const safeSdk1 = await createSafeInstance(signer1, addresses);
-
-    console.log("safe owners", await safeSdk0.getOwners());
-    console.log("signer0", signer0.address);
-    console.log("signer1", signer1.address);
-
-    for (let [_, ethAddress, azeroAddress] of azeroContracts.tokens) {
-      await addTokenPair(ethAddress, azeroAddress, most, [safeSdk0, safeSdk1]);
-    }
-
-    // --- unpause most
-    await unpauseMost(most, [safeSdk0, safeSdk1]);
   }
 
-  // -- update migrations
-  console.log("Updating migrations...");
-  await migrations.setCompleted(3);
+  for (let [_, ethAddress, azeroAddress] of azeroContracts.tokens) {
+    await addTokenPair(ethAddress, azeroAddress, most);
+  }
 
   console.log("Done");
   // NOTE: neccessary because script hangs in CI

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-02-16"
+channel = "nightly-2024-04-28"
 targets = [ "wasm32-unknown-unknown", "x86_64-unknown-linux-musl" ]
 components = [ "rustfmt", "clippy", "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
Simplified deployment script, so it is easy to set up a dev MOST L1 instance, but from the production versions of the contracts.
* Bumped rust toolchain as cargo-contracts 3.2.0 does not build on the current branch nightly anymore
* simplified dev setup to have only one token - WETH 
Please ignore CI - it is a script change only, and CI does not check it anyway.

After merge, this PR will be ported to `master`. 