### PR TITLE
Fixed main CI pipeline

### DIFF
--- a/.github/workflows/contracts-compile-and-deploy-to-devenv.yml
+++ b/.github/workflows/contracts-compile-and-deploy-to-devenv.yml
@@ -69,6 +69,15 @@ jobs:
         run: |
           make deploy-eth NETWORK=sepolia
 
+      - name: Deploy eth contracts (TransferLimit)
+        shell: bash
+        env:
+          SEPOLIA_MNEMONIC: ${{ secrets.DEVENV_TESTNET_SEPOLIA_KEY }}
+          SEPOLIA_ACCOUNT_NUMBER: ${{ secrets.DEVENV_TESTNET_SEPOLIA_ACCOUNT_NUMBER }}
+          SEPOLIA_TOKEN_CONFIG_PATH: "../cfg/tokens_testnet.json"
+        run: |
+          make deploy-eth-transfer-limit NETWORK=sepolia      
+
       - name: Deploy azero contracts
         shell: bash
         run: |

--- a/.github/workflows/contracts-compile-and-deploy-to-devenv.yml
+++ b/.github/workflows/contracts-compile-and-deploy-to-devenv.yml
@@ -3,6 +3,7 @@ name: Devenv - deploy contracts (on demand)
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: "${{ github.ref }}-${{ github.workflow }}"

--- a/.github/workflows/on-master-branch-commit.yml
+++ b/.github/workflows/on-master-branch-commit.yml
@@ -44,3 +44,31 @@ jobs:
     name: Build L2 relayer
     uses: ./.github/workflows/l2-relayer-build.yml
     secrets: inherit
+
+  check-pipeline-completion:
+    needs: [build-l1-relayer,
+            build-l2-relayer]
+    name: Check pipeline completion
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: All nightly tests completed
+        run: |
+          # due to the fact GitHub treats skipped jobs as success, and when any of dependant
+          # jobs fail, this check will be skipped, we need to check status manually
+          jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
+
+  slack:
+    name: Slack notification
+    runs-on: ubuntu-latest
+    needs: [check-pipeline-completion]
+    if: >
+      !cancelled() &&
+      github.event_name != 'workflow_dispatch'
+    steps:
+      - name: Send Slack message
+        uses: Cardinal-Cryptography/github-actions/slack-notification@v7
+        with:
+          notify-on: "failure"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ONDUTY }}

--- a/.github/workflows/on-master-branch-commit.yml
+++ b/.github/workflows/on-master-branch-commit.yml
@@ -12,6 +12,12 @@ jobs:
     uses: ./.github/workflows/_check-vars-and-secrets.yml
     secrets: inherit
 
+  compile-contracts-and-deploy-to-devenv:
+    needs: [check-vars-and-secrets]
+    name: Compile contracts and deploy to devenv
+    uses: ./.github/workflows/contracts-compile-and-deploy-to-devenv.yml
+    secrets: inherit
+
   test-azero-contracts:
     needs: [check-vars-and-secrets]
     uses: ./.github/workflows/test-azero-contracts.yml
@@ -21,13 +27,19 @@ jobs:
     uses: ./.github/workflows/test-eth-contracts.yml
 
   build-l1-relayer:
-    needs: [test-eth-contracts, test-azero-contracts]
+    needs:
+      - test-eth-contracts
+      - test-azero-contracts
+      - compile-contracts-and-deploy-to-devenv
     name: Build L1 relayer
     uses: ./.github/workflows/l1-relayer-build.yml
     secrets: inherit
 
   build-l2-relayer:
-    needs: [test-eth-contracts, test-azero-contracts]
+    needs:
+      - test-eth-contracts
+      - test-azero-contracts
+      - compile-contracts-and-deploy-to-devenv
     name: Build L2 relayer
     uses: ./.github/workflows/l2-relayer-build.yml
     secrets: inherit

--- a/.github/workflows/on-master-branch-commit.yml
+++ b/.github/workflows/on-master-branch-commit.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - A0-192-another-approach
 
 jobs:
   check-vars-and-secrets:

--- a/.github/workflows/on-master-branch-commit.yml
+++ b/.github/workflows/on-master-branch-commit.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - A0-192-another-approach
 
 jobs:
   check-vars-and-secrets:

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,12 @@ deploy-eth: compile-eth
 	npx hardhat run --network $(NETWORK) scripts/0_deploy_bridge_contracts.js \
 	&& npx hardhat run --network $(NETWORK) scripts/deploy_transfer_limit.js
 
+.PHONY: deploy-eth-transfer-limit
+deploy-eth: # Deploy eth contracts
+deploy-eth: compile-eth
+	cd eth && \
+	&& npx hardhat run --network $(NETWORK) scripts/deploy_transfer_limit.js
+
 .PHONY: upload-eth
 upload-eth: # Upload the MOST contract to a live ethereum network (testnet or mainnet) for an upgrade
 upload-eth: compile-eth

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ deploy-eth: compile-eth
 deploy-eth: # Deploy eth contracts
 deploy-eth: compile-eth
 	cd eth && \
-	&& npx hardhat run --network $(NETWORK) scripts/deploy_transfer_limit.js
+	npx hardhat run --network $(NETWORK) scripts/deploy_transfer_limit.js
 
 .PHONY: upload-eth
 upload-eth: # Upload the MOST contract to a live ethereum network (testnet or mainnet) for an upgrade

--- a/Makefile
+++ b/Makefile
@@ -99,12 +99,11 @@ compile-eth: eth-deps
 deploy-eth: # Deploy eth contracts
 deploy-eth: compile-eth
 	cd eth && \
-	npx hardhat run --network $(NETWORK) scripts/0_deploy_bridge_contracts.js \
-	&& npx hardhat run --network $(NETWORK) scripts/deploy_transfer_limit.js
+	npx hardhat run --network $(NETWORK) scripts/0_deploy_bridge_contracts.js
 
 .PHONY: deploy-eth-transfer-limit
-deploy-eth: # Deploy eth contracts
-deploy-eth: compile-eth
+deploy-eth-transfer-limit: # Deploy TransferLimit eth contract
+deploy-eth-transfer-limit: compile-eth
 	cd eth && \
 	npx hardhat run --network $(NETWORK) scripts/deploy_transfer_limit.js
 

--- a/eth/hardhat.config.js
+++ b/eth/hardhat.config.js
@@ -108,7 +108,7 @@ if (SEPOLIA_MNEMONIC || SEPOLIA_PRIVATE_KEY) {
       : [SEPOLIA_PRIVATE_KEY],
     gasPrice: 10e9, // 10 Gwei; it's set to have an upper bound for contract deployment costs
     timeout: 20000, // 20s; if gas prices are higher than 20 Gwei, any tx would likely
-                    // become stuck in the mempool, hence we need a timeout for a deployment script to finish
+    // become stuck in the mempool, hence we need a timeout for a deployment script to finish
     deploymentConfig: {
       guardianIds: [
         typeof SEPOLIA_ACCOUNT_NUMBER == "undefined" ||

--- a/eth/hardhat.config.js
+++ b/eth/hardhat.config.js
@@ -106,6 +106,9 @@ if (SEPOLIA_MNEMONIC || SEPOLIA_PRIVATE_KEY) {
           mnemonic: SEPOLIA_MNEMONIC,
         }
       : [SEPOLIA_PRIVATE_KEY],
+    gasPrice: 10e9, // 10 Gwei; it's set to have an upper bound for contract deployment costs
+    timeout: 20000, // 20s; if gas prices are higher than 20 Gwei, any tx would likely
+                    // become stuck in the mempool, hence we need a timeout for a deployment script to finish
     deploymentConfig: {
       guardianIds: [
         typeof SEPOLIA_ACCOUNT_NUMBER == "undefined" ||


### PR DESCRIPTION
This PR brings back building contracts to main CI pipeline, as some contracts json files are required for a rust relayer build. 

Also, Sepolia prices became lower nowadays to gas price ~= 1 GWEI. This PR sets a bottom limit of gas price to 10 GWEI. This makes it possible to deploy contracts via CI now, with a total amount of 0.05 SETH. This makes it possible to deploy them at least 20 times, assuming CI account has at least 1 SETH. If Sepolia gas price gets more than 10 Gwei, there's a timeout in the deployment scripts that will fail CI again. This is WIP in another PR https://github.com/Cardinal-Cryptography/most/pull/253/files

This PR adds a Slack notification in case of a failed build.

Successful run: https://github.com/Cardinal-Cryptography/most/actions/runs/11270355813